### PR TITLE
[ADD] task to set ready to merge label

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,38 +40,20 @@ setup.py generator
   For addons repositories, run setuptools-odoo-make-defaults, and push
   changes back to github.
 
-Nightly
--------
+These actions are also run nightly on all repos.
 
-...
+On Pull Request review
+----------------------
+
+When there are two approvals, set the ``approved`` label.
+When the PR is at least 5 days old, set the ``ready to merge`` label.
 
 TODO (help wanted)
 ------------------
 
-Intrastructure
-^^^^^^^^^^^^^^
+See our open `issues <https://github.com/OCA/oca-github-bot/issues>`_,
+pick one and contribute!
 
-* In case several webhooks handle the same GitHub event,
-  avoid that one failing hook prevents others to run.
-
-Hooks and tasks
-^^^^^^^^^^^^^^^
-
-* include existing bots here:
-
-  * CLA bot
-  * wheel builder
-  * pypi publisher?
-  * GitHub team members maintenance
-
-* repository maintenance (see repo creation process - cfr OCA Board), eg
-
-  * travis settings
-  * some webhooks (although most webhooks can be put at org level)?
-
-* add a label on PR of new contributors
-* see also https://github.com/OCA/maintainer-tools/pull/346
-* ...
 
 Developing new features
 =======================

--- a/src/oca_github_bot/cron.py
+++ b/src/oca_github_bot/cron.py
@@ -15,4 +15,9 @@ app.conf.beat_schedule = {
         "args": ("OCA",),
         "schedule": crontab(hour="2", minute="30"),
     },
+    "tag_ready_to_merge": {
+        "task": "oca_github_bot.tasks.tag_ready_to_merge.tag_ready_to_merge",
+        "args": ("OCA",),
+        "schedule": crontab(minute="0"),
+    },
 }

--- a/src/oca_github_bot/github.py
+++ b/src/oca_github_bot/github.py
@@ -43,6 +43,14 @@ def gh_call(func, *args, **kwargs):
         raise
 
 
+def gh_date(d):
+    return d.isoformat()
+
+
+def gh_datetime(utc_dt):
+    return utc_dt.isoformat()[:19] + "+00:00"
+
+
 class BranchNotFoundError(RuntimeError):
     pass
 

--- a/src/oca_github_bot/tasks/__init__.py
+++ b/src/oca_github_bot/tasks/__init__.py
@@ -3,3 +3,4 @@
 
 from . import heartbeat
 from . import main_branch_bot
+from . import tag_ready_to_merge

--- a/src/oca_github_bot/tasks/__init__.py
+++ b/src/oca_github_bot/tasks/__init__.py
@@ -3,4 +3,5 @@
 
 from . import heartbeat
 from . import main_branch_bot
+from . import tag_approved
 from . import tag_ready_to_merge

--- a/src/oca_github_bot/tasks/tag_approved.py
+++ b/src/oca_github_bot/tasks/tag_approved.py
@@ -1,0 +1,78 @@
+# Copyright (c) ACSONE SA/NV 2018
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from collections import defaultdict
+
+from .. import github
+from ..github import gh_call
+from ..queue import getLogger, task
+from .tag_ready_to_merge import LABEL_READY_TO_MERGE, tag_ready_to_merge
+
+_logger = getLogger(__name__)
+
+APPROVALS_REQUIRED = 2
+LABEL_APPROVED = "approved"
+
+
+@task()
+def tag_approved(org, repo, pr, dry_run=False):
+    """Add the ``approved`` tag to the given PR if conditions are met.
+
+    Remove it if conditions are not met.
+    """
+    with github.repository(org, repo) as gh_repo:
+        gh_pr = gh_call(gh_repo.pull_request, pr)
+        if not gh_pr.mergeable:
+            # TODO does this exclude merged and closed pr's?
+            # TODO remove approved and ready to merge labels here?
+            _logger.info(f"{gh_pr.url} is not mergeable, exiting")
+            return
+        reviews = list(gh_call(gh_pr.reviews))
+        # obtain last review state for each reviewer
+        review_state_by_user = {}  # login: last review state
+        for review in reviews:
+            if review.state == "COMMENTED":
+                # ignore "commented" review, as they don't change
+                # the review status
+                continue
+            review_state_by_user[review.user.login] = review.state
+        # list users by review status
+        review_users_by_state = defaultdict(set)
+        for login, state in review_state_by_user.items():
+            review_users_by_state[state].add(login)
+        gh_issue = gh_call(gh_pr.issue)
+        labels = [l.name for l in gh_issue.labels()]
+        if (
+            len(review_users_by_state["APPROVED"]) >= APPROVALS_REQUIRED
+            and not review_users_by_state["CHANGES_REQUESTED"]
+        ):
+            if LABEL_APPROVED not in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN add {LABEL_APPROVED} label to PR {gh_pr.url}"
+                    )
+                else:
+                    _logger.info(f"add {LABEL_APPROVED} label to PR {gh_pr.url}")
+                    gh_call(gh_issue.add_labels, LABEL_APPROVED)
+            tag_ready_to_merge.delay(org)
+        else:
+            # remove approved and ready to merge labels
+            if LABEL_APPROVED in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN remove {LABEL_APPROVED} label from PR {gh_pr.url}"
+                    )
+                else:
+                    _logger.info(f"remove {LABEL_APPROVED} label from PR {gh_pr.url}")
+                    gh_call(gh_issue.remove_label, LABEL_APPROVED)
+            if LABEL_READY_TO_MERGE in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN remove {LABEL_READY_TO_MERGE} "
+                        f"label from PR {gh_pr.url}"
+                    )
+                else:
+                    _logger.info(
+                        f"remove {LABEL_READY_TO_MERGE} label from PR {gh_pr.url}"
+                    )
+                    gh_call(gh_issue.remove_label, LABEL_READY_TO_MERGE)

--- a/src/oca_github_bot/tasks/tag_ready_to_merge.py
+++ b/src/oca_github_bot/tasks/tag_ready_to_merge.py
@@ -1,0 +1,91 @@
+# Copyright (c) ACSONE SA/NV 2018
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from .. import github
+from ..github import gh_call
+from ..queue import getLogger, task
+
+_logger = getLogger(__name__)
+
+
+APPROVALS_REQUIRED = 2
+MIN_PR_AGE = timedelta(days=5)
+LABEL_APPROVED = "approved"
+LABEL_READY_TO_MERGE = "ready to merge"
+
+
+@task()
+def tag_ready_to_merge(org, repo, pr, dry_run=False):
+    with github.repository(org, repo) as gh_repo:
+        gh_pr = gh_call(gh_repo.pull_request, pr)
+        if not gh_pr.mergeable:
+            # TODO does this exclude merged and closed pr's?
+            # TODO remove approved and ready to merge labels here?
+            _logger.info(f"{gh_pr.url} is not mergeable, exiting")
+            return
+        reviews = list(gh_call(gh_pr.reviews))
+        # obtain last review state for each reviewer
+        review_state_by_user = {}  # login: last review state
+        for review in reviews:
+            if review.state == "COMMENTED":
+                # ignore "commented" review, as they don't change
+                # the review status
+                continue
+            review_state_by_user[review.user.login] = review.state
+        # list users by review status
+        review_users_by_state = defaultdict(set)
+        for login, state in review_state_by_user.items():
+            review_users_by_state[state].add(login)
+        gh_issue = gh_call(gh_pr.issue)
+        labels = [l.name for l in gh_issue.labels()]
+        if (
+            len(review_users_by_state["APPROVED"]) >= APPROVALS_REQUIRED
+            and not review_users_by_state["CHANGES_REQUESTED"]
+        ):
+            if LABEL_APPROVED not in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN add {LABEL_APPROVED} label to PR {gh_pr.url}"
+                    )
+                else:
+                    gh_call(gh_issue.add_labels, LABEL_APPROVED)
+            merge_eta = gh_pr.created_at + MIN_PR_AGE
+            pr_is_old_enough = datetime.now(gh_pr.created_at.tzinfo) >= merge_eta
+            if pr_is_old_enough:
+                if LABEL_READY_TO_MERGE not in labels:
+                    if dry_run:
+                        _logger.info(
+                            f"DRY-RUN add {LABEL_READY_TO_MERGE} "
+                            f"label to PR {gh_pr.url}"
+                        )
+                    else:
+                        gh_call(gh_issue.add_labels, LABEL_READY_TO_MERGE)
+                        gh_call(
+                            gh_pr.create_comment,
+                            "This PR has been approved by two reviewers and "
+                            "has been created more than 5 days ago. "
+                            "It should therefore be ready to merge by a maintainer "
+                            "(or a PSC member if the concerned addon has "
+                            "no declared maintainer). 🤖",
+                        )
+            else:
+                tag_ready_to_merge.s(org, repo, pr, dry_run).apply_async(eta=merge_eta)
+        else:
+            if LABEL_APPROVED in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN remove {LABEL_APPROVED} label from PR {gh_pr.url}"
+                    )
+                else:
+                    gh_call(gh_issue.remove_label, LABEL_APPROVED)
+            if LABEL_READY_TO_MERGE in labels:
+                if dry_run:
+                    _logger.info(
+                        f"DRY-RUN remove {LABEL_READY_TO_MERGE} "
+                        f"label from PR {gh_pr.url}"
+                    )
+                else:
+                    gh_call(gh_issue.remove_label, LABEL_READY_TO_MERGE)

--- a/src/oca_github_bot/tasks/tag_ready_to_merge.py
+++ b/src/oca_github_bot/tasks/tag_ready_to_merge.py
@@ -26,21 +26,19 @@ def tag_ready_to_merge(org, repo=None, dry_run=False):
     """Add the ``ready to merge`` tag to all PRs where conditions are met."""
     with github.login() as gh:
         max_created = datetime.utcnow() - MIN_PR_AGE
-        query = " ".join(
-            [
-                "type:pr",
-                "state:open",
-                "status:success",
-                "label:approved",
-                '-label:"ready to merge"',
-                f"created:<{gh_datetime(max_created)}",
-            ]
-        )
+        query = [
+            "type:pr",
+            "state:open",
+            "status:success",
+            "label:approved",
+            '-label:"ready to merge"',
+            f"created:<{gh_datetime(max_created)}",
+        ]
         if repo:
             query.append(f"repo:{org}/{repo}")
         else:
             query.append(f"org:{org}")
-        for issue in gh.search_issues(query):
+        for issue in gh.search_issues(" ".join(query)):
             if dry_run:
                 _logger.info(
                     f"DRY-RUN add {LABEL_READY_TO_MERGE} "

--- a/src/oca_github_bot/tasks/tag_ready_to_merge.py
+++ b/src/oca_github_bot/tasks/tag_ready_to_merge.py
@@ -1,91 +1,54 @@
 # Copyright (c) ACSONE SA/NV 2018
 # Distributed under the MIT License (http://opensource.org/licenses/MIT).
 
-from collections import defaultdict
 from datetime import datetime, timedelta
 
 from .. import github
-from ..github import gh_call
+from ..github import gh_call, gh_datetime
 from ..queue import getLogger, task
 
 _logger = getLogger(__name__)
 
 
-APPROVALS_REQUIRED = 2
 MIN_PR_AGE = timedelta(days=5)
-LABEL_APPROVED = "approved"
 LABEL_READY_TO_MERGE = "ready to merge"
+READY_TO_MERGE_COMMENT = (
+    "This PR has the `approved` label and "
+    "has been created more than 5 days ago. "
+    "It should therefore be ready to merge by a maintainer "
+    "(or a PSC member if the concerned addon has "
+    "no declared maintainer). 🤖"
+)
 
 
 @task()
-def tag_ready_to_merge(org, repo, pr, dry_run=False):
-    with github.repository(org, repo) as gh_repo:
-        gh_pr = gh_call(gh_repo.pull_request, pr)
-        if not gh_pr.mergeable:
-            # TODO does this exclude merged and closed pr's?
-            # TODO remove approved and ready to merge labels here?
-            _logger.info(f"{gh_pr.url} is not mergeable, exiting")
-            return
-        reviews = list(gh_call(gh_pr.reviews))
-        # obtain last review state for each reviewer
-        review_state_by_user = {}  # login: last review state
-        for review in reviews:
-            if review.state == "COMMENTED":
-                # ignore "commented" review, as they don't change
-                # the review status
-                continue
-            review_state_by_user[review.user.login] = review.state
-        # list users by review status
-        review_users_by_state = defaultdict(set)
-        for login, state in review_state_by_user.items():
-            review_users_by_state[state].add(login)
-        gh_issue = gh_call(gh_pr.issue)
-        labels = [l.name for l in gh_issue.labels()]
-        if (
-            len(review_users_by_state["APPROVED"]) >= APPROVALS_REQUIRED
-            and not review_users_by_state["CHANGES_REQUESTED"]
-        ):
-            if LABEL_APPROVED not in labels:
-                if dry_run:
-                    _logger.info(
-                        f"DRY-RUN add {LABEL_APPROVED} label to PR {gh_pr.url}"
-                    )
-                else:
-                    gh_call(gh_issue.add_labels, LABEL_APPROVED)
-            merge_eta = gh_pr.created_at + MIN_PR_AGE
-            pr_is_old_enough = datetime.now(gh_pr.created_at.tzinfo) >= merge_eta
-            if pr_is_old_enough:
-                if LABEL_READY_TO_MERGE not in labels:
-                    if dry_run:
-                        _logger.info(
-                            f"DRY-RUN add {LABEL_READY_TO_MERGE} "
-                            f"label to PR {gh_pr.url}"
-                        )
-                    else:
-                        gh_call(gh_issue.add_labels, LABEL_READY_TO_MERGE)
-                        gh_call(
-                            gh_pr.create_comment,
-                            "This PR has been approved by two reviewers and "
-                            "has been created more than 5 days ago. "
-                            "It should therefore be ready to merge by a maintainer "
-                            "(or a PSC member if the concerned addon has "
-                            "no declared maintainer). 🤖",
-                        )
-            else:
-                tag_ready_to_merge.s(org, repo, pr, dry_run).apply_async(eta=merge_eta)
+def tag_ready_to_merge(org, repo=None, dry_run=False):
+    """Add the ``ready to merge`` tag to all PRs where conditions are met."""
+    with github.login() as gh:
+        max_created = datetime.utcnow() - MIN_PR_AGE
+        query = " ".join(
+            [
+                "type:pr",
+                "state:open",
+                "status:success",
+                "label:approved",
+                '-label:"ready to merge"',
+                f"created:<{gh_datetime(max_created)}",
+            ]
+        )
+        if repo:
+            query.append(f"repo:{org}/{repo}")
         else:
-            if LABEL_APPROVED in labels:
-                if dry_run:
-                    _logger.info(
-                        f"DRY-RUN remove {LABEL_APPROVED} label from PR {gh_pr.url}"
-                    )
-                else:
-                    gh_call(gh_issue.remove_label, LABEL_APPROVED)
-            if LABEL_READY_TO_MERGE in labels:
-                if dry_run:
-                    _logger.info(
-                        f"DRY-RUN remove {LABEL_READY_TO_MERGE} "
-                        f"label from PR {gh_pr.url}"
-                    )
-                else:
-                    gh_call(gh_issue.remove_label, LABEL_READY_TO_MERGE)
+            query.append(f"org:{org}")
+        for issue in gh.search_issues(query):
+            if dry_run:
+                _logger.info(
+                    f"DRY-RUN add {LABEL_READY_TO_MERGE} "
+                    f"label to PR {issue.html_url}"
+                )
+            else:
+                _logger.info(f"add {LABEL_READY_TO_MERGE} label to PR {issue.html_url}")
+                gh_issue = issue.issue
+                gh_call(gh_issue.add_labels, LABEL_READY_TO_MERGE)
+                gh_pr = gh_issue.pull_request()
+                gh_call(gh_pr.create_comment, READY_TO_MERGE_COMMENT)

--- a/src/oca_github_bot/webhooks/__init__.py
+++ b/src/oca_github_bot/webhooks/__init__.py
@@ -3,4 +3,5 @@
 
 from . import on_pr_close_delete_branch
 from . import on_pr_open_label_new_contributor
+from . import on_pr_review
 from . import on_push_to_main_branch

--- a/src/oca_github_bot/webhooks/on_pr_review.py
+++ b/src/oca_github_bot/webhooks/on_pr_review.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT License (http://opensource.org/licenses/MIT).
 
 from ..router import router
-from ..tasks.tag_ready_to_merge import tag_ready_to_merge
+from ..tasks.tag_approved import tag_approved
 
 
 @router.register("pull_request_review")
@@ -10,4 +10,4 @@ async def on_pr_review(event, gh, *args, **kwargs):
     """On pull request review, tag if approved or ready to merge."""
     org, repo = event.data["repository"]["full_name"].split("/")
     pr = event.data["pull_request"]["number"]
-    tag_ready_to_merge.delay(org, repo, pr)
+    tag_approved.delay(org, repo, pr)

--- a/src/oca_github_bot/webhooks/on_pr_review.py
+++ b/src/oca_github_bot/webhooks/on_pr_review.py
@@ -1,0 +1,13 @@
+# Copyright (c) ACSONE SA/NV 2018
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from ..router import router
+from ..tasks.tag_ready_to_merge import tag_ready_to_merge
+
+
+@router.register("pull_request_review")
+async def on_pr_review(event, gh, *args, **kwargs):
+    """On pull request review, tag if approved or ready to merge."""
+    org, repo = event.data["repository"]["full_name"].split("/")
+    pr = event.data["pull_request"]["number"]
+    tag_ready_to_merge.delay(org, repo, pr)


### PR DESCRIPTION
Extracted from https://github.com/OCA/maintainer-tools/pull/346

TODO

- [ ] ~cron to run the task nightly on all repos~ (or maybe not: we would quickly explode the API rate limit)
- [x] webhook