### PR TITLE
[FIX] make environment.sample work for docker out of the box

### DIFF
--- a/environment.sample
+++ b/environment.sample
@@ -4,7 +4,7 @@
 #
 
 # redis URI to use for the celery task queue
-#REDIS_URI=redis://localhost:6379
+REDIS_URI=redis://queue
 
 #HTTP_HOST=0.0.0.0
 #HTTP_PORT=8080


### PR DESCRIPTION
this will make it simpler for people to spin up a testing instance I think