### PR TITLE
[ADD] master: needs review label to green pull requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ On Pull Request review
 When there are two approvals, set the ``approved`` label.
 When the PR is at least 5 days old, set the ``ready to merge`` label.
 
+On Pull Request CI status
+-------------------------
+
+When the CI in a Pull Request goes green, set the ``needs review`` label.
+When a Pull Request with the ``needs review`` label is updated and the CI
+fails, remove the ``needs review`` label.
+
 Commands
 --------
 
@@ -170,6 +177,7 @@ Contributors
 * Michel Raich <miquel.raich@eficent.com>
 * Florian Kantelberg <florian.kantelberg@initos.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Jose Angel Fentanez <joseangel@vauxoo.com>
 
 Maintainers
 ===========

--- a/src/oca_github_bot/tasks/__init__.py
+++ b/src/oca_github_bot/tasks/__init__.py
@@ -4,4 +4,5 @@
 from . import heartbeat
 from . import main_branch_bot
 from . import tag_approved
+from . import tag_needs_review
 from . import tag_ready_to_merge

--- a/src/oca_github_bot/tasks/tag_needs_review.py
+++ b/src/oca_github_bot/tasks/tag_needs_review.py
@@ -1,0 +1,33 @@
+from ..github import gh_call, repository
+from ..queue import getLogger, task
+
+_logger = getLogger(__name__)
+
+LABEL_NEEDS_REVIEW = "needs review"
+LABEL_WIP = "work in progress"
+
+
+@task()
+def tag_needs_review(org, pr, repo, status, dry_run=False):
+    """On a successful execution of the CI tests, adds the `needs review`
+    label to the pull request if it doesn't have `wip:` at the
+    begining of the title (case insensitive). Removes the tag if the CI
+    fails.
+    """
+    with repository(org, repo) as gh_repo:
+        gh_pr = gh_call(gh_repo.pull_request, pr)
+        gh_issue = gh_call(gh_pr.issue)
+        labels = [label.name for label in gh_issue.labels()]
+        has_wip = (
+            gh_pr.title.lower().startswith(("wip:", "[wip]")) or LABEL_WIP in labels
+        )
+        if status == "success" and not has_wip:
+            if dry_run:
+                _logger.info(f"DRY-RUN add {LABEL_NEEDS_REVIEW} label")
+            else:
+                gh_call(gh_issue.add_labels, LABEL_NEEDS_REVIEW)
+            return
+        if dry_run:
+            _logger.info(f"DRY-RUN remove {LABEL_NEEDS_REVIEW} label")
+        else:
+            gh_call(gh_issue.remove_label, LABEL_NEEDS_REVIEW)

--- a/src/oca_github_bot/webhooks/__init__.py
+++ b/src/oca_github_bot/webhooks/__init__.py
@@ -3,6 +3,7 @@
 
 from . import on_command
 from . import on_pr_close_delete_branch
+from . import on_pr_green_label_needs_review
 from . import on_pr_open_label_new_contributor
 from . import on_pr_review
 from . import on_push_to_main_branch

--- a/src/oca_github_bot/webhooks/on_pr_green_label_needs_review.py
+++ b/src/oca_github_bot/webhooks/on_pr_green_label_needs_review.py
@@ -1,0 +1,13 @@
+from ..router import router
+from ..tasks.tag_needs_review import tag_needs_review
+
+
+@router.register("check_suite", action="completed")
+async def on_pr_green_label_needs_review(event, gh, *args, **kwargs):
+    """Add the `needs review` label to the pull requests after the successful
+    execution of the CI
+    """
+    status = event.data["check_suite"]["conclusion"]
+    org, repo = event.data["repository"]["full_name"].split("/")
+    pr = event.data["check_suite"]["pull_requests"][0]["number"]
+    tag_needs_review.delay(org, pr, repo, status)

--- a/tests/test_on_pr_green_label_needs_review.py
+++ b/tests/test_on_pr_green_label_needs_review.py
@@ -1,0 +1,21 @@
+import pytest
+from oca_github_bot.webhooks import on_pr_green_label_needs_review
+
+from .common import EventMock
+
+
+@pytest.mark.asyncio
+async def test_on_pr_green_label_needs_review(mocker):
+    mocker.patch(
+        "oca_github_bot.webhooks.on_pr_green_label_needs_review.tag_needs_review.delay"
+    )
+    event = EventMock(
+        data={
+            "repository": {"full_name": "OCA/some-repo"},
+            "check_suite": {"pull_requests": [{"number": 1}], "conclusion": "success"},
+        }
+    )
+    await on_pr_green_label_needs_review.on_pr_green_label_needs_review(event, None)
+    on_pr_green_label_needs_review.tag_needs_review.delay.assert_called_once_with(
+        "OCA", 1, "some-repo", "success"
+    )


### PR DESCRIPTION
This PR adds a method that listens to the `check_suite` webhooks triggered when the CI tests finish in a PR and adds the `needs review` label if the tests were successful and the PR's title doesn't start with `WIP:` (case insensitive). 

If another commit is pushed to the PR and the tests fail, the label is removed.

closes https://github.com/OCA/oca-github-bot/issues/20 