### PR TITLE
Takes the github organisation name from config (default OCA)

### DIFF
--- a/environment.sample
+++ b/environment.sample
@@ -15,6 +15,8 @@ GITHUB_SECRET=
 GITHUB_LOGIN=
 # GitHub oauth token
 GITHUB_TOKEN=
+# Github organisation name (default OCA)
+GITHUB_ORG=
 # Git name and email used for creating commits (default: user git config,
 # needs to be set to to launch the docker composition)
 GIT_NAME=

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -9,6 +9,7 @@ HTTP_PORT = int(os.environ.get("HTTP_PORT") or "8080")
 GITHUB_SECRET = os.environ.get("GITHUB_SECRET")
 GITHUB_LOGIN = os.environ.get("GITHUB_LOGIN")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+GITHUB_ORG = os.environ.get("GITHUB_ORG", "OCA")
 GIT_NAME = os.environ.get("GIT_NAME")
 GIT_EMAIL = os.environ.get("GIT_EMAIL")
 

--- a/src/oca_github_bot/cron.py
+++ b/src/oca_github_bot/cron.py
@@ -3,6 +3,7 @@
 
 from celery.schedules import crontab
 
+from .config import GITHUB_ORG
 from .queue import app
 
 app.conf.beat_schedule = {
@@ -12,12 +13,12 @@ app.conf.beat_schedule = {
     },
     "main_branch_bot_all_repos": {
         "task": "oca_github_bot.tasks.main_branch_bot.main_branch_bot_all_repos",
-        "args": ("OCA",),
+        "args": (GITHUB_ORG,),
         "schedule": crontab(hour="2", minute="30"),
     },
     "tag_ready_to_merge": {
         "task": "oca_github_bot.tasks.tag_ready_to_merge.tag_ready_to_merge",
-        "args": ("OCA",),
+        "args": (GITHUB_ORG,),
         "schedule": crontab(minute="0"),
     },
 }

--- a/src/oca_github_bot/tasks/main_branch_bot.py
+++ b/src/oca_github_bot/tasks/main_branch_bot.py
@@ -23,6 +23,8 @@ def _gen_addons_readme(org, repo, branch, dry_run):
     _logger.info("oca-gen-addon-readme in %s/%s@%s", org, repo, branch)
     gen_addon_readme_cmd = [
         "oca-gen-addon-readme",
+        "--org-name",
+        org,
         "--repo-name",
         repo,
         "--branch",
@@ -50,7 +52,7 @@ def _setuptools_odoo_make_default(org, repo, branch, dry_run):
         "--addons-dir",
         ".",
         "--metapackage",
-        "oca-" + repo,
+        org.lower() + "-" + repo,
         "--clean",
     ]
     if not dry_run:


### PR DESCRIPTION
Allows to specify another github organisation into the confirguration. The goal is to allow the reuse of this bot framework for others organisations.