### PR TITLE
allexport instead of exportall

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,9 +147,9 @@ Here is a recommended procedure to test locally:
 
 .. code::
 
-  set -o exportall
+  set -o allexport
   source environment
-  set +o exportall
+  set +o allexport
 
 * Launch the ``redis`` message queue:
 


### PR DESCRIPTION
source: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html