### PR TITLE
[FIX] Don't duplicate maintainer mentions

### DIFF
--- a/src/oca_github_bot/tasks/mention_maintainer.py
+++ b/src/oca_github_bot/tasks/mention_maintainer.py
@@ -47,10 +47,10 @@ def mention_maintainer(org, repo, pr, dry_run=False):
 
 
 def get_maintainers_mentions(addon_dirs):
-    all_maintainers = list()
+    all_maintainers = set()
     for addon_dir in addon_dirs:
         maintainers = get_manifest(addon_dir).get("maintainers", [])
-        all_maintainers.extend(maintainers)
+        all_maintainers.update(maintainers)
     if not all_maintainers:
         return ""
     all_mentions = map(lambda m: "@" + m, all_maintainers)


### PR DESCRIPTION
If the the Pull Request touches several modules sharing the same maintainer, it would repeat mentions.
This change ensures that each person is mentioned only once.

Example in the wild: https://github.com/OCA/l10n-chile/pull/46#issuecomment-551707048