### PR TITLE
Do not fail on twine check if an addon has no setup.py

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,11 @@
+20191226
+~~~~~~~~
+
+**Bug fixes**
+
+- do not fail on ``twine check`` when an addon has no ``setup.py``
+  `#96 <https://github.com/OCA/oca-github-bot/pull/96>`_
+
 20191126
 ~~~~~~~~
 

--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -12,7 +12,7 @@ from .process import check_call
 _logger = logging.getLogger(__name__)
 
 
-def _build_wheel(addon_dir, dist_dir):
+def _build_and_check_wheel(addon_dir, dist_dir):
     manifest = get_manifest(addon_dir)
     if not manifest.get("installable", True):
         return
@@ -39,6 +39,7 @@ def _build_wheel(addon_dir, dist_dir):
             "py2" if series < (11, 0) else "py3",
         ]
         check_call(cmd, cwd=setup_dir)
+        _check_wheels(dist_dir)
 
 
 def _check_wheels(dist_dir):
@@ -48,14 +49,12 @@ def _check_wheels(dist_dir):
 
 def build_and_check_wheel(addon_dir):
     with tempfile.TemporaryDirectory() as dist_dir:
-        _build_wheel(addon_dir, dist_dir)
-        _check_wheels(dist_dir)
+        _build_and_check_wheel(addon_dir, dist_dir)
 
 
 def build_and_publish_wheel(addon_dir, simple_index_root, dry_run=False):
     with tempfile.TemporaryDirectory() as dist_dir:
-        _build_wheel(addon_dir, dist_dir)
-        _check_wheels(dist_dir)
+        _build_and_check_wheel(addon_dir, dist_dir)
         _publish_dist_dir_to_simple_index(dist_dir, simple_index_root, dry_run)
 
 

--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -15,15 +15,15 @@ _logger = logging.getLogger(__name__)
 def _build_and_check_wheel(addon_dir, dist_dir):
     manifest = get_manifest(addon_dir)
     if not manifest.get("installable", True):
-        return
+        return False
     series = get_odoo_series_from_version(manifest.get("version", ""))
     if series < (8, 0):
-        return
+        return False
     addon_name = os.path.basename(addon_dir)
     setup_dir = os.path.join(addon_dir, "..", "setup", addon_name)
     setup_file = os.path.join(setup_dir, "setup.py")
     if not os.path.isfile(setup_file):
-        return
+        return False
     with tempfile.TemporaryDirectory() as tempdir:
         bdist_dir = os.path.join(tempdir, "build")
         os.mkdir(bdist_dir)
@@ -40,6 +40,7 @@ def _build_and_check_wheel(addon_dir, dist_dir):
         ]
         check_call(cmd, cwd=setup_dir)
         _check_wheels(dist_dir)
+    return True
 
 
 def _check_wheels(dist_dir):
@@ -54,8 +55,8 @@ def build_and_check_wheel(addon_dir):
 
 def build_and_publish_wheel(addon_dir, simple_index_root, dry_run=False):
     with tempfile.TemporaryDirectory() as dist_dir:
-        _build_and_check_wheel(addon_dir, dist_dir)
-        _publish_dist_dir_to_simple_index(dist_dir, simple_index_root, dry_run)
+        if _build_and_check_wheel(addon_dir, dist_dir):
+            _publish_dist_dir_to_simple_index(dist_dir, simple_index_root, dry_run)
 
 
 def build_and_publish_wheels(addons_dir, simple_index_root, dry_run=False):


### PR DESCRIPTION
Typical example: `server_environment_file_sample`