### PR TITLE
ocabot merge: update HISTORY.rst, using oca-towncrier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN set -x \
   && python3 -m venv /ocamt \
   && /ocamt/bin/pip install wheel
 RUN set -x \
-  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@5dbc86310d80229ef0f2f5851933414be719308b#egg=oca-maintainers-tools \
+  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@c7ac2741c02df0ad49ba637e2dca8e67d460af47#egg=oca-maintainers-tools \
   && ln -s /ocamt/bin/oca-gen-addons-table /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-readme /usr/local/bin/ \
-  && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/
+  && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/ \
+  && ln -s /ocamt/bin/oca-towncrier /usr/local/bin/
 RUN set -x \
   && /ocamt/bin/pip install setuptools-odoo>=2.5.0 \
   && ln -s /ocamt/bin/setuptools-odoo-make-default /usr/local/bin/

--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,10 @@ as merge request comments.
 can be used to ask the bot to do the following:
 
 * merge the PR onto a temporary branch created off the target branch
-* run the main branch operations (see above) on it
 * merge when tests on the rebased branch are green
 * optionally bump the version number of the addons modified by the PR
+* when the version was bumped, udate the changelog with ``oca-towncrier``
+* run the main branch operations (see above) on it
 * when the version was bumped, generate a wheel and rsync it to the PEP 503
   simple index
 

--- a/environment.sample
+++ b/environment.sample
@@ -34,7 +34,7 @@ ODOO_PASSWORD=
 # Available tasks:
 #  delete_branch,tag_approved,tag_ready_to_merge,gen_addons_table,
 #  gen_addons_readme,gen_addons_icon,setuptools_odoo,mention_maintainer,
-#  merge_bot,tag_needs_review
+#  merge_bot,merge_bot_towncrier,tag_needs_review
 #BOT_TASKS=all
 
 # Root of the PEP 503 simple index where wheels are published

--- a/newsfragments/106.feature
+++ b/newsfragments/106.feature
@@ -1,0 +1,2 @@
+Make the "ocabot merge" command update ``HISTORY.rst`` from news fragments in
+``readme/newsfragments`` using `towncrier <https://pypi.org/project/towncrier/>`_.


### PR DESCRIPTION
This PR makes the "ocabot merge" command update `HISTORY.rst` from fragments in `readme/newsfragment` using a [thin oca specific wrapper](https://github.com/OCA/maintainer-tools/pull/432) for [towncrier](https://pypi.org/project/towncrier/).