### PR TITLE
[IMP] make APPROVALS_REQUIRED configurable

### DIFF
--- a/environment.sample
+++ b/environment.sample
@@ -31,6 +31,8 @@ ODOO_PASSWORD=
 
 # Number of approvals to have the proposal marked as "Approved"
 #APPROVALS_REQUIRED=2
+# Number of days before the proposal can be marked as "Approved"
+#MIN_PR_AGE=5
 
 # Coma separated list of task to run
 # By default all configured tasks are run.

--- a/environment.sample
+++ b/environment.sample
@@ -29,6 +29,9 @@ ODOO_PASSWORD=
 
 #SENTRY_DSN=
 
+# Number of approvals to have the proposal marked as "Approved"
+#APPROVALS_REQUIRED=2
+
 # Coma separated list of task to run
 # By default all configured tasks are run.
 # Available tasks:

--- a/newsfragments/107.feature
+++ b/newsfragments/107.feature
@@ -1,0 +1,1 @@
+Add ``APPROVALS_REQUIRED`` and ``MIN_PR_AGE`` configuration options to control the conditions to set the ``Approved`` label.

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -87,5 +87,6 @@ MERGE_BOT_INTRO_MESSAGES = [
 ]
 
 APPROVALS_REQUIRED = int(os.environ.get("APPROVALS_REQUIRED", "2"))
+MIN_PR_AGE = int(os.environ.get("MIN_PR_AGE", "5"))
 
 SIMPLE_INDEX_ROOT = os.environ.get("SIMPLE_INDEX_ROOT")

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -86,4 +86,6 @@ MERGE_BOT_INTRO_MESSAGES = [
     "What a great day to merge this nice PR. Let's do it!",
 ]
 
+APPROVALS_REQUIRED = int(os.environ.get("APPROVALS_REQUIRED", "2"))
+
 SIMPLE_INDEX_ROOT = os.environ.get("SIMPLE_INDEX_ROOT")

--- a/src/oca_github_bot/tasks/tag_approved.py
+++ b/src/oca_github_bot/tasks/tag_approved.py
@@ -4,14 +4,13 @@
 from collections import defaultdict
 
 from .. import github
-from ..config import switchable
+from ..config import APPROVALS_REQUIRED, switchable
 from ..github import gh_call
 from ..queue import getLogger, task
 from .tag_ready_to_merge import LABEL_READY_TO_MERGE, tag_ready_to_merge
 
 _logger = getLogger(__name__)
 
-APPROVALS_REQUIRED = 2
 LABEL_APPROVED = "approved"
 
 

--- a/src/oca_github_bot/tasks/tag_ready_to_merge.py
+++ b/src/oca_github_bot/tasks/tag_ready_to_merge.py
@@ -4,14 +4,13 @@
 from datetime import datetime, timedelta
 
 from .. import github
-from ..config import switchable
+from ..config import MIN_PR_AGE, switchable
 from ..github import gh_call, gh_datetime
 from ..queue import getLogger, task
 
 _logger = getLogger(__name__)
 
 
-MIN_PR_AGE = timedelta(days=5)
 LABEL_READY_TO_MERGE = "ready to merge"
 READY_TO_MERGE_COMMENT = (
     "This PR has the `approved` label and "
@@ -27,7 +26,7 @@ READY_TO_MERGE_COMMENT = (
 def tag_ready_to_merge(org, repo=None, dry_run=False):
     """Add the ``ready to merge`` tag to all PRs where conditions are met."""
     with github.login() as gh:
-        max_created = datetime.utcnow() - MIN_PR_AGE
+        max_created = datetime.utcnow() - timedelta(days=MIN_PR_AGE)
         query = [
             "type:pr",
             "state:open",


### PR DESCRIPTION
For the time being, APPROVALS_REQUIRED is hardcoded with the value 2. 

With that PR, it is configurable. 

Note : It is not the perfect design, as the approvals number is dynamic, in the real (OCA) life, and depends on the state of the modules. (stable / Beta / etc...) but it is a little step forward. 

Make also MIN_PR_AGE configurable. 