### PR TITLE
[REF] config and environment.sample files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN set -x \
   && python3 -m venv /ocamt \
   && /ocamt/bin/pip install wheel
 RUN set -x \
-  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@5dbc86310d80229ef0f2f5851933414be719308b#egg=oca-maintainers-tools \
+  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@c7ac2741c02df0ad49ba637e2dca8e67d460af47#egg=oca-maintainers-tools \
   && ln -s /ocamt/bin/oca-gen-addons-table /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-readme /usr/local/bin/ \
-  && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/
+  && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/ \
+  && ln -s /ocamt/bin/oca-towncrier /usr/local/bin/
 RUN set -x \
   && /ocamt/bin/pip install setuptools-odoo>=2.5.0 \
   && ln -s /ocamt/bin/setuptools-odoo-make-default /usr/local/bin/

--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,10 @@ as merge request comments.
 can be used to ask the bot to do the following:
 
 * merge the PR onto a temporary branch created off the target branch
-* run the main branch operations (see above) on it
 * merge when tests on the rebased branch are green
 * optionally bump the version number of the addons modified by the PR
+* when the version was bumped, udate the changelog with ``oca-towncrier``
+* run the main branch operations (see above) on it
 * when the version was bumped, generate a wheel and rsync it to the PEP 503
   simple index
 

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,8 @@ Tasks performed by the bot can be specified by setting the ``BOT_TASKS``
 variable. This is useful if you want to use this bot for your own GitHub
 organisation.
 
+You can also disable a selection of tasks, using ``BOT_TASKS_DISABLED``.
+
 Using docker-compose
 --------------------
 

--- a/environment.sample
+++ b/environment.sample
@@ -42,6 +42,12 @@ ODOO_PASSWORD=
 #  merge_bot,merge_bot_towncrier,tag_needs_review
 #BOT_TASKS=all
 
+# Coma separated list of github status to ignore
+#GITHUB_STATUS_IGNORED=ci/runbot,codecov/project,codecov/patch,coverage/coveralls
+
+# Coma separated list of github Check suites to ignore
+#GITHUB_CHECK_SUITES_IGNORED=Codecov
+
 # Root of the PEP 503 simple index where wheels are published
 # (publishing disabled if empty)
 SIMPLE_INDEX_ROOT=/app/run/simple-index

--- a/environment.sample
+++ b/environment.sample
@@ -42,6 +42,9 @@ ODOO_PASSWORD=
 #  merge_bot,merge_bot_towncrier,tag_needs_review
 #BOT_TASKS=all
 
+# Coma separated list of task to ignore
+#BOT_TASKS_DISABLED=
+
 # Coma separated list of github status to ignore
 #GITHUB_STATUS_IGNORED=ci/runbot,codecov/project,codecov/patch,coverage/coveralls
 

--- a/environment.sample
+++ b/environment.sample
@@ -39,7 +39,7 @@ ODOO_PASSWORD=
 # Available tasks:
 #  delete_branch,tag_approved,tag_ready_to_merge,gen_addons_table,
 #  gen_addons_readme,gen_addons_icon,setuptools_odoo,mention_maintainer,
-#  merge_bot,tag_needs_review
+#  merge_bot,merge_bot_towncrier,tag_needs_review
 #BOT_TASKS=all
 
 # Root of the PEP 503 simple index where wheels are published

--- a/newsfragments/106.feature
+++ b/newsfragments/106.feature
@@ -1,0 +1,2 @@
+Make the "ocabot merge" command update ``HISTORY.rst`` from news fragments in
+``readme/newsfragments`` using `towncrier <https://pypi.org/project/towncrier/>`_.

--- a/newsfragments/109.feature
+++ b/newsfragments/109.feature
@@ -1,0 +1,1 @@
+Add``BOT_TASKS_DISABLED`` and make ``GITHUB_STATUS_IGNORED`` and ``GITHUB_CHECK_SUITES_IGNORED`` configurable.

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -16,7 +16,9 @@ def switchable(switch_name=None):
             if switch_name is None:
                 sname = func.__name__
 
-            if BOT_TASKS != ["all"] and sname not in BOT_TASKS:
+            if (
+                BOT_TASKS != ["all"] and sname not in BOT_TASKS
+            ) or sname in BOT_TASKS_DISABLED:
                 _logger.debug("Method %s skipped (Disabled by config)", sname)
                 return
             return func(*args, **kwargs)
@@ -47,12 +49,9 @@ SENTRY_DSN = os.environ.get("SENTRY_DSN")
 
 DRY_RUN = os.environ.get("DRY_RUN", "").lower() in ("1", "true", "yes")
 
-# Coma separated list of task to run
-# By default all configured tasks are run.
-# Available tasks:
-#  delete_branch,tag_approved,tag_ready_to_merge,gen_addons_table,
-#  gen_addons_readme,gen_addons_icon,setuptools_odoo,merge_bot,tag_needs_review
 BOT_TASKS = os.environ.get("BOT_TASKS", "all").split(",")
+
+BOT_TASKS_DISABLED = os.environ.get("BOT_TASKS_DISABLED", "").split(",")
 
 GEN_ADDONS_TABLE_EXTRA_ARGS = (
     os.environ.get("GEN_ADDONS_TABLE_EXTRA_ARGS", "")

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -72,13 +72,15 @@ GEN_ADDON_ICON_EXTRA_ARGS = (
     or []
 )
 
-GITHUB_STATUS_IGNORED = [
-    "ci/runbot",
-    "codecov/project",
-    "codecov/patch",
-    "coverage/coveralls",
-]
-GITHUB_CHECK_SUITES_IGNORED = ["Codecov"]
+GITHUB_STATUS_IGNORED = os.environ.get(
+    "GITHUB_STATUS_IGNORED",
+    "ci/runbot,codecov/project,codecov/patch,coverage/coveralls",
+).split(",")
+
+GITHUB_CHECK_SUITES_IGNORED = os.environ.get(
+    "GITHUB_CHECK_SUITES_IGNORED", "Codecov"
+).split(",")
+
 MERGE_BOT_INTRO_MESSAGES = [
     "On my way to merge this fine PR!",
     "This PR looks fantastic, let's merge it!",

--- a/tests/test_switchable.py
+++ b/tests/test_switchable.py
@@ -18,6 +18,10 @@ def test_switchable_method():
     assert config.BOT_TASKS == ["all"]
     assert ping_method("test") == "test"
     assert ping_method_2("test") == "test"
+    config.BOT_TASKS_DISABLED = ["ping_method"]
+    assert ping_method("test") is None
+    assert ping_method_2("test") == "test"
+    config.BOT_TASKS_DISABLED = []
     config.BOT_TASKS = []
     assert ping_method("test") is None
     assert ping_method_2("test") is None


### PR DESCRIPTION
This PR provides a refactoring of ``config.py`` and ``environment.sample`` files.

When I discovered this project, I was quite lost between that two files because some things was in one or in the other, (or in both). So this PR is an attempt to make a little clean and remove duplicated code or comment.

**Before this PR :**
1) some default values was present in the ``environment.sample`` file, other in the ``config.py`` file, other in both.

2) Some description was present in both files like for ``BOT_TASKS`` value, and inconsistent between two files (keys was missing) : 
Description 1 : https://github.com/OCA/oca-github-bot/blob/master/src/oca_github_bot/config.py#L50
Description 2 : https://github.com/OCA/oca-github-bot/blob/master/environment.sample#L37

3) ``GITHUB_STATUS_IGNORED`` and ``GITHUB_CHECK_SUITES_IGNORED`` was hardcoded in ``config.py`` file, and so not configurable.

4) ``BOT_TASKS`` was enumerating the tasks to run. So during an upgrade of the lib, if the value was ``all``, the new features was enabled by default (without changing the ``environment`` file) but if the value was not ``all`` the new features was disabled by default, that is not consistent. So ``BOT_TASKS`` is replace by ``BOT_TASKS_IGNORED`` assuming that most of the time, only some features are disabled and we want to have new features enabled by default.

**Important Note :**
Once merged (if accepted ;-)), the custom ``environment`` file should be updated for the existing bots that are running. (At least the OCA one) adding the following keys. (if not still defined with a custom values.)
```
HTTP_PORT=8080
APPROVALS_REQUIRED=2
MIN_PR_AGE=5
GITHUB_STATUS_IGNORED=ci/runbot,codecov/project,codecov/patch,coverage/coveralls
GITHUB_CHECK_SUITES_IGNORED=Codecov
# If current BOT_TASKS value is "all"
BOT_TASKS_IGNORED=
# Otherwise, set the list of the tasks to skip
BOT_TASKS_IGNORED=task_1,task_2
```