### PR TITLE
[IMP] add nobump option for 'merge' command. Make bumpversion_mode re…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Commands
 One can ask the bot to perform some tasks by entering special commands
 as merge request comments.
 
-``/ocabot merge`` optionally followed by one of ``major``, ``minor``, ``patch``,
+``/ocabot merge`` followed by one of ``major``, ``minor``, ``patch`` or ``nobump``
 can be used to ask the bot to do the following:
 
 * merge the PR onto a temporary branch created off the target branch

--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,7 @@ Contributors
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Jose Angel Fentanez <joseangel@vauxoo.com>
 * Simone Rubino <simone.rubino@agilebg.com>
+* Sylvain Le Gal (https://twitter.com/legalsylvain)
 
 Maintainers
 ===========

--- a/environment.sample
+++ b/environment.sample
@@ -64,3 +64,8 @@ SIMPLE_INDEX_ROOT=/app/run/simple-index
 #GEN_ADDONS_TABLE_EXTRA_ARGS=
 #GEN_ADDON_README_EXTRA_ARGS=
 #GEN_ADDON_ICON_EXTRA_ARGS=
+
+# Text displayed on github, as a comment,
+# if a user has entered a wrong command
+#OCABOT_USAGE=
+#OCABOT_EXTRA_DOCUMENTATION=

--- a/newsfragments/90.feature
+++ b/newsfragments/90.feature
@@ -1,1 +1,2 @@
 Make ``bumpversion_mode`` option required on ``merge`` command, adding ``nobump`` option that was before implicit.
+Bot adds comment on github, if the command is wrong. Message are customizable in the ``environment`` file.

--- a/newsfragments/90.feature
+++ b/newsfragments/90.feature
@@ -1,0 +1,1 @@
+Make ``bumpversion_mode`` option required on ``merge`` command, adding ``nobump`` option that was before implicit.

--- a/src/oca_github_bot/commands.py
+++ b/src/oca_github_bot/commands.py
@@ -21,18 +21,23 @@ BOT_COMMAND_RE = re.compile(
 )
 
 
-class InvalidCommandError(Exception):
+class CommandError(Exception):
+    pass
+
+
+class InvalidCommandError(CommandError):
     def __init__(self, name):
         super().__init__(f"Invalid command: {name}")
 
 
-class OptionsError(Exception):
+class OptionsError(CommandError):
     pass
 
 
 class InvalidOptionsError(OptionsError):
     def __init__(self, name, options):
-        super().__init__(f"Invalid options for command {name}: {options}")
+        options_text = " ".join(options)
+        super().__init__(f"Invalid options for command {name}: {options_text}")
 
 
 class RequiredOptionError(OptionsError):

--- a/src/oca_github_bot/commands.py
+++ b/src/oca_github_bot/commands.py
@@ -26,9 +26,22 @@ class InvalidCommandError(Exception):
         super().__init__(f"Invalid command: {name}")
 
 
-class InvalidOptionsError(Exception):
+class OptionsError(Exception):
+    pass
+
+
+class InvalidOptionsError(OptionsError):
     def __init__(self, name, options):
         super().__init__(f"Invalid options for command {name}: {options}")
+
+
+class RequiredOptionError(OptionsError):
+    def __init__(self, name, option, values):
+        values_text = ", ".join(values)
+        super().__init__(
+            f"Required option {option} for command {name}.\n"
+            f"Possible values : {values_text}"
+        )
 
 
 class BotCommand:
@@ -53,24 +66,22 @@ class BotCommand:
 
 
 class BotCommandMerge(BotCommand):
-    bumpversion_mode = None  # optional str: major|minor|patch
+    bumpversion_mode = None
+    bumpversion_mode_list = ["major", "minor", "patch", "nobump"]
 
     def parse_options(self, options):
         if not options:
-            return
-        if len(options) == 1 and options[0] in ("major", "minor", "patch"):
+            raise RequiredOptionError(
+                self.name, "bumpversion_mode", self.bumpversion_mode_list
+            )
+        if len(options) == 1 and options[0] in self.bumpversion_mode_list:
             self.bumpversion_mode = options[0]
         else:
             raise InvalidOptionsError(self.name, options)
 
     def delay(self, org, repo, pr, username, dry_run=False):
         merge_bot.merge_bot_start.delay(
-            org,
-            repo,
-            pr,
-            username,
-            bumpversion_mode=self.bumpversion_mode,
-            dry_run=False,
+            org, repo, pr, username, self.bumpversion_mode, dry_run=False
         )
 
 

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -91,3 +91,17 @@ APPROVALS_REQUIRED = int(os.environ.get("APPROVALS_REQUIRED", "2"))
 MIN_PR_AGE = int(os.environ.get("MIN_PR_AGE", "5"))
 
 SIMPLE_INDEX_ROOT = os.environ.get("SIMPLE_INDEX_ROOT")
+
+OCABOT_USAGE = os.environ.get(
+    "OCABOT_USAGE",
+    "**Ocabot commands**\n" "* ``ocabot merge major|minor|patch|nobump``",
+)
+
+OCABOT_EXTRA_DOCUMENTATION = os.environ.get(
+    "OCABOT_EXTRA_DOCUMENTATION",
+    "**More information**\n"
+    " * [ocabot documentation](https://github.com/OCA/oca-github-bot/#commands)\n"
+    " * [OCA guidelines](https://github.com/OCA/odoo-community.org/blob/master/"
+    "website/Contribution/CONTRIBUTING.rst), "
+    'specially the "Version Numbers" section.',
+)

--- a/src/oca_github_bot/tasks/add_pr_comment.py
+++ b/src/oca_github_bot/tasks/add_pr_comment.py
@@ -1,0 +1,12 @@
+# Copyright (c) GRAP SCIC SA 2020 (http://www.grap.coop)
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from .. import github
+from ..queue import task
+
+
+@task()
+def add_pr_comment(org, repo, pr, message):
+    with github.login() as gh:
+        gh_pr = gh.pull_request(org, repo, pr)
+        github.gh_call(gh_pr.create_comment, message)

--- a/src/oca_github_bot/tasks/merge_bot.py
+++ b/src/oca_github_bot/tasks/merge_bot.py
@@ -142,7 +142,7 @@ def _merge_bot_merge_pr(org, repo, merge_bot_branch, cwd, dry_run=False):
     ]
 
     # update HISTORY.rst using towncrier, before generating README.rst
-    if bumpversion_mode:
+    if bumpversion_mode != "nobump":
         _merge_bot_towncrier(
             org,
             repo,
@@ -159,7 +159,7 @@ def _merge_bot_merge_pr(org, repo, merge_bot_branch, cwd, dry_run=False):
     for addon_dir in modified_installable_addon_dirs:
         # TODO wlc lock and push
         # TODO msgmerge and commit
-        if bumpversion_mode:
+        if bumpversion_mode != "nobump":
             # bumpversion is last commit (after readme generation etc
             # and before building wheel),
             # so setuptools-odoo generates a round version number
@@ -174,7 +174,11 @@ def _merge_bot_merge_pr(org, repo, merge_bot_branch, cwd, dry_run=False):
             ["git", "push", "origin", f"{merge_bot_branch}:{target_branch}"], cwd=cwd
         )
     # build and publish wheel
-    if bumpversion_mode and modified_installable_addon_dirs and SIMPLE_INDEX_ROOT:
+    if (
+        bumpversion_mode != "nobump"
+        and modified_installable_addon_dirs
+        and SIMPLE_INDEX_ROOT
+    ):
         for addon_dir in modified_installable_addon_dirs:
             build_and_publish_wheel(addon_dir, SIMPLE_INDEX_ROOT, dry_run)
     # TODO wlc unlock modified_addons
@@ -245,7 +249,7 @@ def merge_bot_start(
     repo,
     pr,
     username,
-    bumpversion_mode=None,
+    bumpversion_mode,
     dry_run=False,
     intro_message=None,
     merge_strategy=MergeStrategy.merge,

--- a/src/oca_github_bot/version_branch.py
+++ b/src/oca_github_bot/version_branch.py
@@ -34,7 +34,7 @@ def parse_merge_bot_branch(branch):
     mo = MERGE_BOT_BRANCH_RE.match(branch)
     bumpversion_mode = mo.group("bumpversion_mode")
     if bumpversion_mode == "no":
-        bumpversion_mode = None
+        bumpversion_mode = "nobump"
     return (
         mo.group("pr"),
         mo.group("target_branch"),

--- a/tests/test_version_branch.py
+++ b/tests/test_version_branch.py
@@ -50,7 +50,7 @@ def test_parse_merge_bot_branch():
         "100",
         "12.0",
         "toto",
-        None,
+        "nobump",
     )
 
 


### PR DESCRIPTION
- Add a fourth key ``nobump`` for the option ``bumpversion_mode`` of the command ``merge``
- Make ``bumpversion_mode`` required. (close #90)
