### PR TITLE
Ignore Dependabot in check-suite

### DIFF
--- a/newsfragments/115.feature
+++ b/newsfragments/115.feature
@@ -1,0 +1,1 @@
+Ignore Dependabot by default in check-suite ignores, along with Codecov.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ billiard==3.5.0.4         # via celery
 bleach==3.1.4             # via readme-renderer
 celery[redis]==4.2.1
 certifi==2018.10.15       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via aiohttp, requests
 cryptography==2.3.1       # via jwcrypto
 docutils==0.14            # via readme-renderer

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -77,7 +77,7 @@ GITHUB_STATUS_IGNORED = os.environ.get(
 ).split(",")
 
 GITHUB_CHECK_SUITES_IGNORED = os.environ.get(
-    "GITHUB_CHECK_SUITES_IGNORED", "Codecov"
+    "GITHUB_CHECK_SUITES_IGNORED", "Codecov,Dependabot"
 ).split(",")
 
 MERGE_BOT_INTRO_MESSAGES = [


### PR DESCRIPTION
The check-suites GitHub api-call started reporting Dependabot in queued state, preventing merges.
It should be safe to ignore it by default.