### PR TITLE
Dockerfile: refresh maintainer tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: python
 
 python:
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
 
 matrix:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
   && python3 -m venv /ocamt \
   && /ocamt/bin/pip install wheel
 RUN set -x \
-  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@c7ac2741c02df0ad49ba637e2dca8e67d460af47#egg=oca-maintainers-tools \
+  && /ocamt/bin/pip install -e git+https://github.com/OCA/maintainer-tools@73c47b6835bee3ab0eeeff7c463de6b9c085abbc#egg=oca-maintainers-tools \
   && ln -s /ocamt/bin/oca-gen-addons-table /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-readme /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/ \

--- a/newsfragments/118.bugfix
+++ b/newsfragments/118.bugfix
@@ -1,0 +1,3 @@
+Update maintainer-tools to get the latest ``oca-gen-addon-tables``. It fixes a
+regression where the main branch operations were failing when ``README.md`` is
+absent.


### PR DESCRIPTION
Update maintainer-tools to get the latest `oca-gen-addon-tables`. It fixes a regression where the main branch operations were failing when `README.md` is absent.