### PR TITLE
[IMP] merge: publish wheels also in nobump mode

### DIFF
--- a/newsfragments/123.feature
+++ b/newsfragments/123.feature
@@ -1,0 +1,3 @@
+Publish wheels also in nobump mode. This exception was probably done with the
+goal of saving space, but for migration PRs where people use ``ocabot merge
+nobump``, we want to publish too.


### PR DESCRIPTION
This exception was probably done with the goal of saving space,
but for migration PRs where people use ocabot merge nobump,
we want to publish too.