### PR TITLE
Ignore check suites that have no check runs

### DIFF
--- a/newsfragments/141.feature
+++ b/newsfragments/141.feature
@@ -1,0 +1,2 @@
+Ignore check suites that have no check runs. This should cope repos that have
+no ``.travis.yml`` but where Travis is enabled at organization level.


### PR DESCRIPTION
Previously, there was a hack to ignore Travis check suites when the old style travis status was present.
Then we had to ignore Dependabot which was reporting a check suite that never completed.
Now, on repos that have no .travis.yml but where travis is configured organization-wide, we have Travis reporting a check suite that never completes. :/

So this is an attempt to better handle all this by ignoring check suites that have no check runs.

Also, improve logging in this area.

Why it is so hard to detect a green build... I may miss something obvious... or not.