### PR TITLE
[FIX] migration_issue_bot: String replacements fine tuning

### DIFF
--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -34,10 +34,17 @@ def _set_lines_issue(gh_pr, issue, module):
     module_list = False
     new_line = f"- [ ] {module} - By @{gh_pr.user.login} - #{gh_pr.number}"
     for line in issue.body.split("\n"):
-        if line.startswith(f"- [ ] {module}"):
-            lines.append(new_line)
+        if added:  # Bypass the checks for faster completion
+            lines.append(line)
             continue
-        elif not added:
+        groups = re.match(fr"^- \[( |x)\] {module}( |$)", line)
+        if groups:  # Line found
+            # Respect check mark status if existing
+            new_line = new_line[:3] + groups[1] + new_line[4:]
+            lines.append(new_line)
+            added = True
+            continue
+        else:
             splits = re.split(r"- \[ \] ([0-9a-zA-Z_]*)", line)
             if len(splits) >= 2:
                 # Flag for detecting if we have passed already module list


### PR DESCRIPTION
- Don't replace only on the start of the string. This can lead to multiple matches on modules starting with the same name. Although the rest of the added code now avoid to make more than one replacement, it's good to still do the exact match. This is provided through a regular expression matching the module name + space or the end of the line.
- Provide line filling shortcut for faster completion.
- Preserve possible existing mark check.

@Tecnativa