### PR TITLE
[FIX] migration_issue_bot: Line ending + already checked marks

### DIFF
--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -37,7 +37,7 @@ def _set_lines_issue(gh_pr, issue, module):
         if added:  # Bypass the checks for faster completion
             lines.append(line)
             continue
-        groups = re.match(fr"^- \[( |x)\] {module}( |$)", line)
+        groups = re.match(fr"^- \[( |x)\] {module}( |\r)", line)
         if groups:  # Line found
             # Respect check mark status if existing
             new_line = new_line[:3] + groups[1] + new_line[4:]
@@ -45,7 +45,7 @@ def _set_lines_issue(gh_pr, issue, module):
             added = True
             continue
         else:
-            splits = re.split(r"- \[ \] ([0-9a-zA-Z_]*)", line)
+            splits = re.split(r"- \[[ |x]\] ([0-9a-zA-Z_]*)", line)
             if len(splits) >= 2:
                 # Flag for detecting if we have passed already module list
                 module_list = True


### PR DESCRIPTION
This commit includes 2 fixes:

- Add to the regular expression that detects the line the carrier return (\r), as `$` is not representing the same as it's fed from the issue text.
- For detecting if the module list has ended, we were not taking into account that there can be modules already migrated, and thus, the `x` should be included in such regular expression.

@Tecnativa