### PR TITLE
Hide secrets when commenting on PRs

### DIFF
--- a/src/oca_github_bot/tasks/merge_bot.py
+++ b/src/oca_github_bot/tasks/merge_bot.py
@@ -23,6 +23,7 @@ from ..manifest import (
 )
 from ..process import CalledProcessError, call, check_call
 from ..queue import getLogger, task
+from ..utils import hide_secrets
 from ..version_branch import make_merge_bot_branch, parse_merge_bot_branch
 from .main_branch_bot import main_branch_bot_actions
 
@@ -287,15 +288,19 @@ def merge_bot_start(
             cmd = " ".join(e.cmd)
             github.gh_call(
                 gh_pr.create_comment,
-                f"@{username} The merge process could not start, because "
-                f"command `{cmd}` failed with output:\n```\n{e.output}\n```",
+                hide_secrets(
+                    f"@{username} The merge process could not start, because "
+                    f"command `{cmd}` failed with output:\n```\n{e.output}\n```"
+                ),
             )
             raise
         except Exception as e:
             github.gh_call(
                 gh_pr.create_comment,
-                f"@{username} The merge process could not start, because "
-                f"of exception {e}.",
+                hide_secrets(
+                    f"@{username} The merge process could not start, because "
+                    f"of exception {e}."
+                ),
             )
             raise
         else:
@@ -305,7 +310,7 @@ def merge_bot_start(
 
 
 def _get_commit_success(org, repo, pr, gh_commit):
-    """ Test commit status, using both status and check suites APIs """
+    """Test commit status, using both status and check suites APIs"""
     success = None  # None means don't know / in progress
     gh_status = github.gh_call(gh_commit.status)
     for status in gh_status.statuses:
@@ -396,17 +401,21 @@ def merge_bot_status(org, repo, merge_bot_branch, sha):
                     cmd = " ".join(e.cmd)
                     github.gh_call(
                         gh_pr.create_comment,
-                        f"@{username} The merge process could not be "
-                        f"finalized, because "
-                        f"command `{cmd}` failed with output:\n```\n{e.output}\n```",
+                        hide_secrets(
+                            f"@{username} The merge process could not be "
+                            f"finalized, because "
+                            f"command `{cmd}` failed with output:\n```\n{e.output}\n```"
+                        ),
                     )
                     _remove_merging_label(github, gh_pr)
                     raise
                 except Exception as e:
                     github.gh_call(
                         gh_pr.create_comment,
-                        f"@{username} The merge process could not be "
-                        f"finalized because an exception was raised: {e}.",
+                        hide_secrets(
+                            f"@{username} The merge process could not be "
+                            f"finalized because an exception was raised: {e}."
+                        ),
                     )
                     _remove_merging_label(github, gh_pr)
                     raise

--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -9,6 +9,7 @@ from ..config import switchable
 from ..manifest import user_can_push
 from ..process import check_call
 from ..queue import task
+from ..utils import hide_secrets
 
 
 def _create_or_find_branch_milestone(gh_repo, branch):
@@ -113,7 +114,9 @@ def migration_issue_start(org, repo, pr, username, module=None, dry_run=False):
         except Exception as e:
             github.gh_call(
                 gh_pr.create_comment,
-                f"@{username} The migration issue commenter process could not "
-                f"start, because of exception {e}.",
+                hide_secrets(
+                    f"@{username} The migration issue commenter process could not "
+                    f"start, because of exception {e}."
+                ),
             )
             raise

--- a/src/oca_github_bot/tasks/rebase_bot.py
+++ b/src/oca_github_bot/tasks/rebase_bot.py
@@ -6,6 +6,7 @@ from ..config import switchable
 from ..manifest import user_can_push
 from ..process import CalledProcessError, check_call
 from ..queue import getLogger, task
+from ..utils import hide_secrets
 
 _logger = getLogger(__name__)
 
@@ -99,13 +100,17 @@ def rebase_bot_start(org, repo, pr, username, dry_run=False):
             cmd = " ".join(e.cmd)
             github.gh_call(
                 gh_pr.create_comment,
-                f"@{username} The rebase process failed, because "
-                f"command `{cmd}` failed with output:\n```\n{e.output}\n```",
+                hide_secrets(
+                    f"@{username} The rebase process failed, because "
+                    f"command `{cmd}` failed with output:\n```\n{e.output}\n```"
+                ),
             )
             raise
         except Exception as e:
             github.gh_call(
                 gh_pr.create_comment,
-                f"@{username} The rebase process failed, because of exception {e}.",
+                hide_secrets(
+                    f"@{username} The rebase process failed, because of exception {e}."
+                ),
             )
             raise

--- a/src/oca_github_bot/utils.py
+++ b/src/oca_github_bot/utils.py
@@ -1,0 +1,9 @@
+# Copyright (c) ACSONE SA/NV 2021
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from . import config
+
+
+def hide_secrets(s: str) -> str:
+    # TODO do we want to hide other secrets ?
+    return s.replace(config.GITHUB_TOKEN, "***")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+# Copyright (c) ACSONE SA/NV 2021
+# Distributed under the MIT License (http://opensource.org/licenses/MIT).
+
+from oca_github_bot.utils import hide_secrets
+
+from .common import set_config
+
+
+def test_hide_secrets_nothing_to_hide():
+    with set_config(GITHUB_TOKEN="token"):
+        assert "nothing to hide" == hide_secrets("nothing to hide")
+
+
+def test_hide_secrets_github_token():
+    with set_config(GITHUB_TOKEN="token"):
+        assert "git push https://***@github.com" == hide_secrets(
+            "git push https://token@github.com"
+        )


### PR DESCRIPTION
Writing github bots is hard.

We happen to be leaking a secret. Example here: https://github.com/OCA/maintenance/pull/157#issuecomment-981837484
This explains why our GitHub token was revoked.