### PR TITLE
Ignore BranchNotFoundError in merge status task

### DIFF
--- a/newsfragments/178.bugfix
+++ b/newsfragments/178.bugfix
@@ -1,0 +1,2 @@
+Reduce error noise by suppressing BranchNotFoundError in then merge branch status
+handler.


### PR DESCRIPTION
This avoids some error noise in case branches have been deleted
before status webhooks are invoked or before the task has a chance
to run.