### PR TITLE
[FIX] environment.sample : remove space that make build failing

### DIFF
--- a/environment.sample
+++ b/environment.sample
@@ -60,9 +60,7 @@ SIMPLE_INDEX_ROOT=/app/run/simple-index
 # - repo url, for twine --repository-url
 # - username for twine --username option
 # - password for twine --password option
-OCABOT_TWINE_REPOSITORIES="[
-    ('https://pypi.org/simple', 'https://upload.pypi.org/legacy/', 'pypiuser', 'pypipassword'),
-]"
+OCABOT_TWINE_REPOSITORIES="[('https://pypi.org/simple','https://upload.pypi.org/legacy/','pypiuser','pypipassword')]"
 
 # Space separated list of extra arguments, for the calls of the
 # following command


### PR DESCRIPTION
Trivial fix.

**Step to reproduce :** 
- install the oca-github-bot
- create an ``environment`` file based on the ``environment.sample`` file.
- run docker-compose up --build

**Result**
```
ERROR: In file /home/user/grap_dev/grap-ocabot-env/src/oca-github-bot/environment: environment variable name '('https://pypi.org/simple', 'https://upload.pypi.org/legacy/', 'pypiuser', 'pypipassword'),' may not contain whitespace.
```