### PR TITLE
[IMP] Search addons maintainers in other branches. Fix : #122

### DIFF
--- a/environment.sample
+++ b/environment.sample
@@ -80,3 +80,7 @@ OCABOT_TWINE_REPOSITORIES="[('https://pypi.org/simple','https://upload.pypi.org/
 # Markdown text to be used to call for maintainers when a PR is made to an
 # addon that has no declared maintainers.
 #ADOPT_AN_ADDON_MENTION=
+
+# List of branches the bot will check to verify if user is the maintainer
+# of module(s)
+MAINTAINER_CHECK_ODOO_RELEASES=8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0

--- a/newsfragments/183.bugfix
+++ b/newsfragments/183.bugfix
@@ -1,0 +1,1 @@
+Search for addons maintainers in all the branches of the current repository.

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -130,3 +130,9 @@ OCABOT_EXTRA_DOCUMENTATION = os.environ.get(
 )
 
 ADOPT_AN_ADDON_MENTION = os.environ.get("ADOPT_AN_ADDON_MENTION")
+
+MAINTAINER_CHECK_ODOO_RELEASES = (
+    os.environ.get("MAINTAINER_CHECK_ODOO_RELEASES")
+    and os.environ.get("MAINTAINER_CHECK_ODOO_RELEASES").split(",")
+    or []
+)

--- a/src/oca_github_bot/manifest.py
+++ b/src/oca_github_bot/manifest.py
@@ -267,11 +267,10 @@ def is_maintainer_other_branches(org, repo, username, modified_addons, other_bra
         is_maintainer = False
         for branch in other_branches:
             manifest_file = (
-                float(branch) < 10.0 and "__openerp__.py" or "__manifest__.py"
+                "__openerp__.py" if float(branch) < 10.0 else "__manifest__.py"
             )
             url = (
-                f"https://raw.githubusercontent.com/{org}/{repo}/{branch}/"
-                f"{addon}/{manifest_file}"
+                f"https://github.com/{org}/{repo}/raw/{branch}/{addon}/{manifest_file}"
             )
             _logger.debug("Looking for maintainers in %s" % url)
             r = requests.get(

--- a/src/oca_github_bot/manifest.py
+++ b/src/oca_github_bot/manifest.py
@@ -77,8 +77,9 @@ def get_manifest_path(addon_dir):
     return None
 
 
-def parse_manifest(manifest: bytes)-> dict:
+def parse_manifest(manifest: bytes) -> dict:
     return ast.literal_eval(manifest.decode("utf-8"))
+
 
 def get_manifest(addon_dir):
     manifest_path = get_manifest_path(addon_dir)

--- a/src/oca_github_bot/manifest.py
+++ b/src/oca_github_bot/manifest.py
@@ -77,12 +77,15 @@ def get_manifest_path(addon_dir):
     return None
 
 
+def parse_manifest(manifest: bytes)-> dict:
+    return ast.literal_eval(manifest.decode("utf-8"))
+
 def get_manifest(addon_dir):
     manifest_path = get_manifest_path(addon_dir)
     if not manifest_path:
         raise NoManifestFound(f"no manifest found in {addon_dir}")
-    with open(manifest_path, "r") as f:
-        return ast.literal_eval(f.read())
+    with open(manifest_path, "rb") as f:
+        return parse_manifest(f.read())
 
 
 def set_manifest_version(addon_dir, version):
@@ -277,7 +280,7 @@ def is_maintainer_other_branches(org, repo, username, modified_addons, other_bra
                 url, allow_redirects=True, headers={"Cache-Control": "no-cache"}
             )
             if r.ok:
-                manifest = ast.literal_eval(r.content.decode("utf-8"))
+                manifest = parse_manifest(r.content)
                 if username in manifest.get("maintainers", []):
                     is_maintainer = True
                     break

--- a/src/oca_github_bot/tasks/mention_maintainer.py
+++ b/src/oca_github_bot/tasks/mention_maintainer.py
@@ -33,7 +33,7 @@ def mention_maintainer(org, repo, pr, dry_run=False):
                 cwd=clonedir,
             )
             check_call(["git", "checkout", pr_branch], cwd=clonedir)
-            modified_addon_dirs, _ = git_modified_addon_dirs(clonedir, target_branch)
+            modified_addon_dirs, _, _ = git_modified_addon_dirs(clonedir, target_branch)
 
             # Remove not installable addons
             # (case where an addon becomes no more installable).

--- a/src/oca_github_bot/tasks/merge_bot.py
+++ b/src/oca_github_bot/tasks/merge_bot.py
@@ -131,7 +131,7 @@ def _merge_bot_merge_pr(org, repo, merge_bot_branch, cwd, dry_run=False):
     # to the PR.
     check_call(["git", "fetch", "origin", f"refs/pull/{pr}/head:tmp-pr-{pr}"], cwd=cwd)
     check_call(["git", "checkout", f"tmp-pr-{pr}"], cwd=cwd)
-    modified_addon_dirs, _ = git_modified_addon_dirs(cwd, target_branch)
+    modified_addon_dirs, _, _ = git_modified_addon_dirs(cwd, target_branch)
     # Run main branch bot actions before bump version.
     # Do not run the main branch bot if there are no modified addons,
     # because it is dedicated to addons repos.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -20,6 +20,7 @@ from oca_github_bot.manifest import (
     is_addon_dir,
     is_addons_dir,
     is_maintainer,
+    is_maintainer_other_branches,
     set_manifest_version,
 )
 
@@ -140,6 +141,7 @@ def test_git_modified_addons(git_clone):
     assert git_modified_addon_dirs(git_clone, "origin/master") == (
         [str(git_clone / "addon")],
         False,
+        {"addon"},
     )
     # add a second addon, and change the first one
     addon2_dir = git_clone / "addon2"
@@ -234,3 +236,12 @@ def test_is_maintainer(tmp_path):
     assert is_maintainer("u2", [addon1, addon2])
     assert not is_maintainer("u2", [addon1, addon2, addon3])
     assert not is_maintainer("u1", [tmp_path / "not_an_addon"])
+
+
+def test_is_maintainer_other_branches():
+    assert is_maintainer_other_branches(
+        "OCA", "mis-builder", "sbidoul", {"mis_builder"}, ["12.0"]
+    )
+    assert not is_maintainer_other_branches(
+        "OCA", "mis-builder", "fpdoo", {"mis_builder"}, ["12.0"]
+    )

--- a/tests/test_mention_maintainer.py
+++ b/tests/test_mention_maintainer.py
@@ -20,7 +20,7 @@ def test_maintainer_mentioned(git_clone, mocker):
     modified_addons_mock = mocker.patch(
         "oca_github_bot.tasks.mention_maintainer.git_modified_addon_dirs"
     )
-    modified_addons_mock.return_value = [addon_dir], False
+    modified_addons_mock.return_value = [addon_dir], False, {addon_name}
     mocker.patch("oca_github_bot.tasks.mention_maintainer.check_call")
     mention_maintainer("org", "repo", "pr")
 
@@ -53,7 +53,7 @@ def test_added_maintainer_not_mentioned(git_clone, mocker):
     modified_addons_mock = mocker.patch(
         "oca_github_bot.tasks.mention_maintainer.git_modified_addon_dirs"
     )
-    modified_addons_mock.return_value = [pre_pr_addon], False
+    modified_addons_mock.return_value = [pre_pr_addon], False, {addon_name}
 
     mocker.patch("oca_github_bot.tasks.mention_maintainer.check_call")
 
@@ -79,7 +79,7 @@ def test_multi_maintainer_one_mention(git_clone, mocker):
     modified_addons_mock = mocker.patch(
         "oca_github_bot.tasks.mention_maintainer.git_modified_addon_dirs"
     )
-    modified_addons_mock.return_value = addon_dirs, False
+    modified_addons_mock.return_value = addon_dirs, False, set(addon_names)
     mocker.patch("oca_github_bot.tasks.mention_maintainer.check_call")
     mention_maintainer("org", "repo", "pr")
 
@@ -105,7 +105,7 @@ def test_pr_by_maintainer_no_mention(git_clone, mocker):
     modified_addons_mock = mocker.patch(
         "oca_github_bot.tasks.mention_maintainer.git_modified_addon_dirs"
     )
-    modified_addons_mock.return_value = addon_dirs, False
+    modified_addons_mock.return_value = addon_dirs, False, set(addon_names)
     mocker.patch("oca_github_bot.tasks.mention_maintainer.check_call")
     mention_maintainer("org", "repo", "pr")
 
@@ -123,7 +123,7 @@ def test_no_maintainer_adopt_module(git_clone, mocker):
     modified_addons_mock = mocker.patch(
         "oca_github_bot.tasks.mention_maintainer.git_modified_addon_dirs"
     )
-    modified_addons_mock.return_value = [addon_dir], False
+    modified_addons_mock.return_value = [addon_dir], False, {addon_name}
     mocker.patch("oca_github_bot.tasks.mention_maintainer.check_call")
 
     with set_config(ADOPT_AN_ADDON_MENTION="Hi {pr_opener}, would you like to adopt?"):


### PR DESCRIPTION
Search for maintainers in all the branches, to make possible maintainer to merge migration PRs. (#122)
Note, it works also for the past. (If i'm declared as maintainers of a 12.0 module, I will also have the possibility to merge PR against 8.0 (for backport / fixes / etc...)

**Deployment Note**
Once deployed, you should update your ``environment`` file. if not, the feature will be simply anavailable.
