### PR TITLE
[IMP] make _set_lines_issue working on empty issue

### DIFF
--- a/newsfragments/190.bugfix
+++ b/newsfragments/190.bugfix
@@ -1,0 +1,1 @@
+Make the command ``/ocabot migration`` working when migration issue doesn't contain migration module lines.

--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -58,6 +58,10 @@ def _set_lines_issue(gh_pr, issue, module):
                 lines.append(new_line)
                 added = True
         lines.append(line)
+
+    # make the addition working on an empty migration issue
+    if not added:
+        lines.append(new_line)
     return lines
 
 

--- a/tests/test_migration_issue_bot.py
+++ b/tests/test_migration_issue_bot.py
@@ -31,9 +31,34 @@ def test_find_issue(gh):
 
 @pytest.mark.vcr()
 def test_set_lines_issue(gh):
-    repo = _get_repository(gh, "OCA", "contract")
-    milestone = _create_or_find_branch_milestone(repo, "14.0")
-    issue = _find_issue(repo, milestone, "14.0")
-    gh_pr = gh.pull_request("OCA", "contract", 705)
-    lines = _set_lines_issue(gh_pr, issue, "contract")
-    assert len(lines) > 0
+    module = "mis_builder"
+    gh_pr_user_login = "sbidoul"
+    gh_pr_number = 11
+
+    body_transformation = [
+        (
+            "Issue with list but not the module\n"
+            "- [ ] a_module_1 - By @legalsylvain - #1\n"
+            "- [ ] z_module_1 - By @pedrobaeza - #2",
+            f"Issue with list but not the module\n"
+            f"- [ ] a_module_1 - By @legalsylvain - #1\n"
+            f"- [ ] {module} - By @{gh_pr_user_login} - #{gh_pr_number}\n"
+            f"- [ ] z_module_1 - By @pedrobaeza - #2",
+        ),
+        (
+            f"Issue with list containing the module\n"
+            f"- [x] {module} - By @legalsylvain - #1\n"
+            f"- [ ] z_module_1 - By @pedrobaeza - #2",
+            f"Issue with list containing the module\n"
+            f"- [x] {module} - By @{gh_pr_user_login} - #{gh_pr_number}\n"
+            f"- [ ] z_module_1 - By @pedrobaeza - #2",
+        ),
+        (
+            "Issue with no list",
+            f"Issue with no list\n"
+            f"- [ ] {module} - By @{gh_pr_user_login} - #{gh_pr_number}",
+        ),
+    ]
+    for (old_body, new_body_expected) in body_transformation:
+        new_body = _set_lines_issue(gh_pr_user_login, gh_pr_number, old_body, module)
+        assert new_body == new_body_expected


### PR DESCRIPTION
Hi.

when calling ``/ocabot migration``, if the issue doesn't contains lines, the command fail silently. (that is due to the github api I guess. If we "edit" an github issue, and write the same text as before, the write is ignored).

with that patch, the line is added at the end of the migration issue body.

**Context** 
- can be used on custom modules, if we don't want to initialize the repository.
- usefull also in the Openupgrade project (See : https://github.com/OCA/OpenUpgrade/issues/3288#issuecomment-1157036504 
with the decision to not populate migration issue).

CC : @pedrobaeza, @sbidoul 

thanks for your review.
