### PR TITLE
[ADD] add warning in ocabot migration if previous PR was present for the same module

### DIFF
--- a/newsfragments/191.feature
+++ b/newsfragments/191.feature
@@ -1,0 +1,1 @@
+When calling ``/ocabot migration`` if a previous Pull Request was referenced in the migration issue, post an alert on the new Pull Request to mention the previous work.

--- a/tests/test_migration_issue_bot.py
+++ b/tests/test_migration_issue_bot.py
@@ -60,5 +60,5 @@ def test_set_lines_issue(gh):
         ),
     ]
     for (old_body, new_body_expected) in body_transformation:
-        new_body = _set_lines_issue(gh_pr_user_login, gh_pr_number, old_body, module)
+        new_body, _ = _set_lines_issue(gh_pr_user_login, gh_pr_number, old_body, module)
         assert new_body == new_body_expected


### PR DESCRIPTION
**Use case**
- When maintainers are calling ``ocabot migration`` 
- if previous PR was present, 

**Current behaviour** 
The line of the migration issue is replaced silently by the new PR. (and new author).
However, in many cases, it is a duplication of work.

**Current workaround**

Maintainers should take a look on the migration issue, to check if an existing PR still exist and alert on the PR. See for exemple : https://github.com/OCA/OpenUpgrade/pull/3334#issuecomment-1164117298
For repos with a large amount of modules, it is very complicated to remember that a porting is already in progress.

**With that PR**

If an existing PR is referenced in the migration issue, a message is added to the new PR by the bot, referencing the first PR and pinging the original author.

![image](https://user-images.githubusercontent.com/3407482/176914448-c74d5f7b-31a7-4726-bab7-cbfe732dbbeb.png)


CC : 
- @sbidoul 
- @pedrobaeza, you could be interested by this one ?

Note : tested with ngrox on a grap repo. See : https://github.com/grap-org-test-bot/github-ocabot-test/pull/29#issuecomment-1172407880
