### PR TITLE
[IMP] ocabot merge : check line in migration issue

### DIFF
--- a/newsfragments/192.bugfix
+++ b/newsfragments/192.bugfix
@@ -1,0 +1,1 @@
+Automaticaly check line in Migration issue when merging the according Pull Request.

--- a/src/oca_github_bot/tasks/merge_bot.py
+++ b/src/oca_github_bot/tasks/merge_bot.py
@@ -27,7 +27,7 @@ from ..queue import getLogger, task
 from ..utils import hide_secrets
 from ..version_branch import make_merge_bot_branch, parse_merge_bot_branch
 from .main_branch_bot import main_branch_bot_actions
-from .migration_issue_bot import _check_line_issue, _find_issue
+from .migration_issue_bot import _mark_migration_done_in_migration_issue
 
 _logger = getLogger(__name__)
 
@@ -204,10 +204,7 @@ def _merge_bot_merge_pr(org, repo, merge_bot_branch, cwd, dry_run=False):
         github.gh_call(gh_pr.close)
 
         # Check line in migration issue if required
-        migration_issue = _find_issue(gh_repo, target_branch)
-        if migration_issue:
-            new_body = _check_line_issue(gh_pr.number, migration_issue.body)
-            migration_issue.edit(body=new_body)
+        _mark_migration_done_in_migration_issue(gh_repo, target_branch, gh_pr)
     return True
 
 

--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -29,6 +29,18 @@ def _find_issue(gh_repo, milestone, target_branch):
     return issue
 
 
+def _check_line_issue(gh_pr_number, issue_body):
+    lines = []
+    regex = r"\#%s\b" % gh_pr_number
+    for line in issue_body.split("\n"):
+        if re.findall(regex, line):
+            checked_line = line.replace("[ ]", "[x]", 1)
+            lines.append(checked_line)
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
 def _set_lines_issue(gh_pr_user_login, gh_pr_number, issue_body, module):
     lines = []
     added = False

--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -83,6 +83,13 @@ def _set_lines_issue(gh_pr_user_login, gh_pr_number, issue_body, module):
     return "\n".join(lines), old_pr_number
 
 
+def _mark_migration_done_in_migration_issue(gh_repo, target_branch, gh_pr):
+    migration_issue = _find_issue(gh_repo, target_branch)
+    if migration_issue:
+        new_body = _check_line_issue(gh_pr.number, migration_issue.body)
+        migration_issue.edit(body=new_body)
+
+
 @task()
 @switchable("migration_issue_bot")
 def migration_issue_start(org, repo, pr, username, module=None, dry_run=False):

--- a/tests/test_migration_issue_bot.py
+++ b/tests/test_migration_issue_bot.py
@@ -4,6 +4,7 @@
 import pytest
 
 from oca_github_bot.tasks.migration_issue_bot import (
+    _check_line_issue,
     _create_or_find_branch_milestone,
     _find_issue,
     _set_lines_issue,
@@ -70,3 +71,25 @@ def test_set_lines_issue(gh):
     for old_body, new_body_expected in body_transformation:
         new_body, _ = _set_lines_issue(gh_pr_user_login, gh_pr_number, old_body, module)
         assert new_body == new_body_expected
+
+
+@pytest.mark.vcr()
+def test_check_line_issue(gh):
+    module = "mis_builder"
+    gh_pr_user_login = "sbidoul"
+    gh_pr_number = 11
+
+    old_body = (
+        f"Issue with list containing the module\n"
+        f"- [ ] a_module_1 - By @legalsylvain - #1\n"
+        f"- [ ] {module} - By @{gh_pr_user_login} - #{gh_pr_number}\n"
+        f"- [ ] z_module_1 - By @pedrobaeza - #2"
+    )
+    new_body_expected = (
+        f"Issue with list containing the module\n"
+        f"- [ ] a_module_1 - By @legalsylvain - #1\n"
+        f"- [x] {module} - By @{gh_pr_user_login} - #{gh_pr_number}\n"
+        f"- [ ] z_module_1 - By @pedrobaeza - #2"
+    )
+    new_body = _check_line_issue(gh_pr_number, old_body)
+    assert new_body == new_body_expected


### PR DESCRIPTION
**Rational**

When maintainers are merging migration PR, they have to manually go to the according migration issue, and check the according line.
This operation is sometimes forgotten, and could be automated. 

This PR introduces that feature.

Fix : #189 
Discussion reference : https://github.com/OCA/OpenUpgrade/issues/3288#issuecomment-1157007829

CC : @sbidoul, @pedrobaeza 

Tested with ngrox : See edited migration issue by the bot here : https://github.com/grap-org-test-bot/github-ocabot-test/issues/27 (1 July 2022 17h46)