### PR TITLE
Refactor wheel builder

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = strict

--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -10,6 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Tuple, Union
 
+from .config import WHEEL_BUILD_TOOLS
 from .manifest import addon_dirs_in, get_manifest, get_odoo_series_from_version
 from .process import check_call
 from .pypi import DistPublisher
@@ -18,13 +19,6 @@ _logger = logging.getLogger(__name__)
 
 
 class Builder:
-    BUILD_TOOLS = [
-        "pip",
-        "setuptools<58",
-        "wheel",
-        "setuptools-odoo",
-        "whool",
-    ]
     _builder: Union["Builder", None] = None
 
     @classmethod
@@ -42,7 +36,7 @@ class Builder:
             cwd=".",
         )
         check_call(
-            [self.env_python, "-m", "pip", "install", "--upgrade"] + self.BUILD_TOOLS,
+            [self.env_python, "-m", "pip", "install", "--upgrade"] + WHEEL_BUILD_TOOLS,
             cwd=".",
         )
 

--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -1,80 +1,143 @@
 # Copyright (c) ACSONE SA/NV 2019
 # Distributed under the MIT License (http://opensource.org/licenses/MIT).
 
+import atexit
 import logging
 import os
+import shutil
 import sys
 import tempfile
+from pathlib import Path
+from typing import Tuple, Union
 
 from .manifest import addon_dirs_in, get_manifest, get_odoo_series_from_version
 from .process import check_call
+from .pypi import DistPublisher
 
 _logger = logging.getLogger(__name__)
 
 
-def _bdist_wheel(setup_dir, dist_dir, python_tag=None):
-    with tempfile.TemporaryDirectory() as tempdir:
-        bdist_dir = os.path.join(tempdir, "build")
-        os.mkdir(bdist_dir)
-        cmd = [
-            sys.executable,
-            "setup.py",
-            "bdist_wheel",
-            "--dist-dir",
-            dist_dir,
-            "--bdist-dir",
-            bdist_dir,
-        ]
-        if python_tag:
-            cmd.extend(["--python-tag", python_tag])
-        check_call(cmd, cwd=setup_dir)
-        _check_wheels(dist_dir)
+class Builder:
+    BUILD_TOOLS = [
+        "pip",
+        "setuptools<58",
+        "wheel",
+        "setuptools-odoo",
+        "whool",
+    ]
+    _builder: Union["Builder", None] = None
 
+    @classmethod
+    def get(cls) -> "Builder":
+        if cls._builder is None:
+            cls._builder = cls()
+        return cls._builder
 
-def _build_and_check_wheel(addon_dir, dist_dir):
-    manifest = get_manifest(addon_dir)
-    if not manifest.get("installable", True):
+    def __init__(self):
+        self.env_dir = tempfile.mkdtemp()
+        atexit.register(shutil.rmtree, self.env_dir)
+        self.env_python = Path(self.env_dir) / "bin" / "python"
+        check_call(
+            [sys.executable, "-m", "venv", self.env_dir],
+            cwd=".",
+        )
+        check_call(
+            [self.env_python, "-m", "pip", "install", "--upgrade"] + self.BUILD_TOOLS,
+            cwd=".",
+        )
+
+    def build_wheel(self, project_dir: Path, dist_dir: str) -> None:
+        check_call(
+            [
+                self.env_python,
+                "-m",
+                "build",
+                "--wheel",
+                "--outdir",
+                dist_dir,
+                "--no-isolation",
+            ],
+            cwd=project_dir,
+        )
+        self._check_wheels(dist_dir)
+        return True
+
+    def build_wheel_legacy(
+        self, project_dir: Path, dist_dir: str, python_tag: Union[str, None] = None
+    ) -> None:
+        with tempfile.TemporaryDirectory() as bdist_dir:
+            cmd = [
+                self.env_python,
+                "setup.py",
+                "bdist_wheel",
+                "--dist-dir",
+                dist_dir,
+                "--bdist-dir",
+                bdist_dir,
+            ]
+            if python_tag:
+                cmd.extend(["--python-tag", python_tag])
+            check_call(cmd, cwd=project_dir)
+        self._check_wheels(dist_dir)
+        return True
+
+    def _check_wheels(self, dist_dir: Path) -> None:
+        wheels = [f for f in os.listdir(dist_dir) if f.endswith(".whl")]
+        check_call(["twine", "check"] + wheels, cwd=dist_dir)
+
+    def build_addon_wheel(self, addon_dir: Path, dist_dir: str) -> None:
+        manifest = get_manifest(addon_dir)
+        if not manifest.get("installable", True):
+            return False
+
+        series = get_odoo_series_from_version(manifest.get("version", ""))
+
+        if series >= (11, 0) and (addon_dir / "pyproject.toml").is_file():
+            return self.build_wheel(addon_dir, dist_dir)
+
+        setup_py_dir = addon_dir / ".." / "setup" / addon_dir.name
+        if series >= (8, 0) and (setup_py_dir / "setup.py").is_file():
+            return self.build_wheel_legacy(
+                setup_py_dir, dist_dir, python_tag="py2" if series < (11, 0) else "py3"
+            )
+
         return False
-    series = get_odoo_series_from_version(manifest.get("version", ""))
-    if series < (8, 0):
-        return False
-    addon_name = os.path.basename(addon_dir)
-    setup_dir = os.path.join(addon_dir, "..", "setup", addon_name)
-    setup_file = os.path.join(setup_dir, "setup.py")
-    if not os.path.isfile(setup_file):
-        return False
-    _bdist_wheel(setup_dir, dist_dir, python_tag="py2" if series < (11, 0) else "py3")
-    return True
 
 
-def _check_wheels(dist_dir):
-    wheels = [f for f in os.listdir(dist_dir) if f.endswith(".whl")]
-    check_call(["twine", "check"] + wheels, cwd=dist_dir)
-
-
-def build_and_check_wheel(addon_dir):
+def build_and_check_wheel(addon_dir: str):
     with tempfile.TemporaryDirectory() as dist_dir:
-        _build_and_check_wheel(addon_dir, dist_dir)
+        Builder.get().build_addon_wheel(Path(addon_dir), dist_dir)
 
 
-def build_and_publish_wheel(addon_dir, dist_publisher, dry_run):
+def build_and_publish_wheel(
+    addon_dir: str, dist_publisher: DistPublisher, dry_run: bool
+):
     with tempfile.TemporaryDirectory() as dist_dir:
-        if _build_and_check_wheel(addon_dir, dist_dir):
+        if Builder.get().build_addon_wheel(Path(addon_dir), dist_dir):
             dist_publisher.publish(dist_dir, dry_run)
 
 
-def build_and_publish_wheels(addons_dir, dist_publisher, dry_run):
+def build_and_publish_wheels(
+    addons_dir: str, dist_publisher: DistPublisher, dry_run: bool
+):
     for addon_dir in addon_dirs_in(addons_dir, installable_only=True):
-        build_and_publish_wheel(addon_dir, dist_publisher, dry_run)
+        with tempfile.TemporaryDirectory() as dist_dir:
+            if Builder.get().build_addon_wheel(Path(addon_dir), dist_dir):
+                dist_publisher.publish(dist_dir, dry_run)
 
 
-def build_and_publish_metapackage_wheel(addons_dir, dist_publisher, series, dry_run):
+def build_and_publish_metapackage_wheel(
+    addons_dir: str,
+    dist_publisher: DistPublisher,
+    series: Tuple[int, int],
+    dry_run: bool,
+):
     setup_dir = os.path.join(addons_dir, "setup", "_metapackage")
     setup_file = os.path.join(setup_dir, "setup.py")
     if not os.path.isfile(setup_file):
         return
     with tempfile.TemporaryDirectory() as dist_dir:
-        _bdist_wheel(
-            setup_dir, dist_dir, python_tag="py2" if series < (11, 0) else "py3"
-        )
-        dist_publisher.publish(dist_dir, dry_run)
+        if Builder.get().build_wheel_legacy(
+            Path(setup_dir), dist_dir, python_tag="py2" if series < (11, 0) else "py3"
+        ):
+            dist_publisher.publish(dist_dir, dry_run)

--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -86,7 +86,7 @@ class Builder:
 
         series = get_odoo_series_from_version(manifest.get("version", ""))
 
-        if series >= (11, 0) and (addon_dir / "pyproject.toml").is_file():
+        if series >= (12, 0) and (addon_dir / "pyproject.toml").is_file():
             return self.build_wheel(addon_dir, dist_dir)
 
         setup_py_dir = addon_dir / ".." / "setup" / addon_dir.name

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -137,3 +137,8 @@ MAINTAINER_CHECK_ODOO_RELEASES = (
     and os.environ.get("MAINTAINER_CHECK_ODOO_RELEASES").split(",")
     or []
 )
+
+WHEEL_BUILD_TOOLS = os.environ.get(
+    "WHEEL_BUILD_TOOLS",
+    "build,pip,setuptools<58,wheel,setuptools-odoo,whool",
+).split(",")

--- a/src/oca_github_bot/manifest.py
+++ b/src/oca_github_bot/manifest.py
@@ -5,6 +5,7 @@ import ast
 import logging
 import os
 import re
+from typing import Tuple
 
 import requests
 
@@ -216,7 +217,7 @@ def get_odoo_series_from_version(version):
     return tuple(int(s) for s in series.split("."))
 
 
-def get_odoo_series_from_branch(branch):
+def get_odoo_series_from_branch(branch) -> Tuple[int, int]:
     mo = BRANCH_RE.match(branch)
     if not mo:
         raise OdooSeriesNotDetected()

--- a/tests/test_build_wheels.py
+++ b/tests/test_build_wheels.py
@@ -3,6 +3,9 @@
 
 import os
 import subprocess
+import textwrap
+
+import pytest
 
 from oca_github_bot.build_wheels import (
     build_and_publish_metapackage_wheel,
@@ -18,22 +21,36 @@ def _init_git_repo(cwd):
     subprocess.check_call(["git", "config", "user.email", "test@example.com"], cwd=cwd)
 
 
-def _make_addon(addons_dir, addon_name, series, metapackage=None):
+def _make_addon(
+    addons_dir, addon_name, series, metapackage=None, setup_py=True, pyproject=False
+):
     addon_dir = addons_dir / addon_name
     addon_dir.mkdir()
     manifest_path = addon_dir / "__manifest__.py"
     manifest_path.write_text(repr({"name": addon_name, "version": series + ".1.0.0"}))
-    (addon_dir / "__ini__.py").write_text("")
+    (addon_dir / "__init__.py").write_text("")
+    if pyproject:
+        (addon_dir / "pyproject.toml").write_text(
+            textwrap.dedent(
+                """\
+                [build-system]
+                requires = ["whool"]
+                build-backend = "whool.buildapi"
+                """
+            )
+        )
     subprocess.check_call(["git", "add", addon_name], cwd=addons_dir)
     subprocess.check_call(["git", "commit", "-m", "add " + addon_name], cwd=addons_dir)
     subprocess.check_call(["git", "clean", "-ffdx", "--", "setup"], cwd=addons_dir)
-    cmd = ["setuptools-odoo-make-default", "-d", str(addons_dir), "--commit"]
-    if metapackage:
-        cmd.extend(["--metapackage", metapackage])
-    subprocess.check_call(cmd)
+    if setup_py:
+        cmd = ["setuptools-odoo-make-default", "-d", str(addons_dir), "--commit"]
+        if metapackage:
+            cmd.extend(["--metapackage", metapackage])
+        subprocess.check_call(cmd)
 
 
-def test_build_and_publish_wheels(tmp_path):
+@pytest.mark.parametrize("setup_py", [True, False])
+def test_build_and_publish_wheels(setup_py, tmp_path):
     addons_dir = tmp_path / "addons_dir"
     addons_dir.mkdir()
     _init_git_repo(addons_dir)
@@ -44,7 +61,7 @@ def test_build_and_publish_wheels(tmp_path):
     build_and_publish_wheels(addons_dir, dist_publisher, dry_run=False)
     assert not os.listdir(simple_index_root)
     # build with one addon
-    _make_addon(addons_dir, "addon1", "12.0")
+    _make_addon(addons_dir, "addon1", "12.0", setup_py=setup_py, pyproject=not setup_py)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = os.listdir(simple_index_root)
     assert len(wheel_dirs) == 1
@@ -55,7 +72,7 @@ def test_build_and_publish_wheels(tmp_path):
     assert wheels[0].endswith(".whl")
     assert "-py3-" in wheels[0]
     # build with two addons
-    _make_addon(addons_dir, "addon2", "10.0")
+    _make_addon(addons_dir, "addon2", "10.0", setup_py=setup_py, pyproject=not setup_py)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = sorted(os.listdir(simple_index_root))
     assert len(wheel_dirs) == 2
@@ -66,7 +83,7 @@ def test_build_and_publish_wheels(tmp_path):
     assert wheels[0].endswith(".whl")
     assert "-py2-" in wheels[0]
     # test tag for Odoo 11
-    _make_addon(addons_dir, "addon3", "11.0")
+    _make_addon(addons_dir, "addon3", "11.0", setup_py=setup_py, pyproject=not setup_py)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = sorted(os.listdir(simple_index_root))
     assert len(wheel_dirs) == 3
@@ -75,7 +92,7 @@ def test_build_and_publish_wheels(tmp_path):
     assert len(wheels) == 1
     assert "-py2.py3-" in wheels[0]
     # test Odoo 15+ default addon naming scheme
-    _make_addon(addons_dir, "addon4", "15.0")
+    _make_addon(addons_dir, "addon4", "15.0", setup_py=setup_py, pyproject=not setup_py)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = sorted(os.listdir(simple_index_root))
     assert len(wheel_dirs) == 4

--- a/tests/test_build_wheels.py
+++ b/tests/test_build_wheels.py
@@ -27,7 +27,15 @@ def _make_addon(
     addon_dir = addons_dir / addon_name
     addon_dir.mkdir()
     manifest_path = addon_dir / "__manifest__.py"
-    manifest_path.write_text(repr({"name": addon_name, "version": series + ".1.0.0"}))
+    manifest_path.write_text(
+        repr(
+            {
+                "name": addon_name,
+                "version": series + ".1.0.0",
+                "description": "...",
+            }
+        )
+    )
     (addon_dir / "__init__.py").write_text("")
     if pyproject:
         (addon_dir / "pyproject.toml").write_text(
@@ -71,8 +79,8 @@ def test_build_and_publish_wheels(setup_py, tmp_path):
     assert wheels[0].startswith("odoo12_addon_addon1")
     assert wheels[0].endswith(".whl")
     assert "-py3-" in wheels[0]
-    # build with two addons
-    _make_addon(addons_dir, "addon2", "10.0", setup_py=setup_py, pyproject=not setup_py)
+    # build with two addons, don't use pyproject.toml for this version
+    _make_addon(addons_dir, "addon2", "10.0", setup_py=True, pyproject=False)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = sorted(os.listdir(simple_index_root))
     assert len(wheel_dirs) == 2
@@ -82,8 +90,8 @@ def test_build_and_publish_wheels(setup_py, tmp_path):
     assert wheels[0].startswith("odoo10_addon_addon2")
     assert wheels[0].endswith(".whl")
     assert "-py2-" in wheels[0]
-    # test tag for Odoo 11
-    _make_addon(addons_dir, "addon3", "11.0", setup_py=setup_py, pyproject=not setup_py)
+    # test tag for Odoo 11, don't use pyproject.toml for this version
+    _make_addon(addons_dir, "addon3", "11.0", setup_py=True, pyproject=False)
     build_and_publish_wheels(str(addons_dir), dist_publisher, dry_run=False)
     wheel_dirs = sorted(os.listdir(simple_index_root))
     assert len(wheel_dirs) == 3


### PR DESCRIPTION
- reuse the build environment for performance (and stability if/when we pin build tools versions)
- support (and give priority to) `pyproject.toml` in addon directories, towards removing the `setup` directories

TODO
- [x] test with a pyproject-enabled addon