### PR TITLE
[FIX] _mark_migration_done_in_migration_issue : Call _find_issue with correct number of parameters

### DIFF
--- a/src/oca_github_bot/tasks/migration_issue_bot.py
+++ b/src/oca_github_bot/tasks/migration_issue_bot.py
@@ -84,7 +84,8 @@ def _set_lines_issue(gh_pr_user_login, gh_pr_number, issue_body, module):
 
 
 def _mark_migration_done_in_migration_issue(gh_repo, target_branch, gh_pr):
-    migration_issue = _find_issue(gh_repo, target_branch)
+    milestone = _create_or_find_branch_milestone(gh_repo, target_branch)
+    migration_issue = _find_issue(gh_repo, milestone, target_branch)
     if migration_issue:
         new_body = _check_line_issue(gh_pr.number, migration_issue.body)
         migration_issue.edit(body=new_body)


### PR DESCRIPTION
Blind commit. (not tested).

Should fix @pedrobaeza remarks https://github.com/OCA/oca-github-bot/pull/192#issuecomment-1596218816

CC : @sbidoul.

Don't understand how it could have worked in my test (https://github.com/grap-org-test-bot/github-ocabot-test/issues/27), but well !