### PR TITLE
Generate pyproject.toml instead of setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,11 @@ RUN set -x \
   && python3 -m venv /ocamt \
   && /ocamt/bin/pip install --no-cache-dir -U pip wheel
 RUN set -x \
-  && /ocamt/bin/pip install --no-cache-dir -e git+https://github.com/OCA/maintainer-tools@969238e47c07d0c40573acff81d170f63245d738#egg=oca-maintainers-tools \
+  && /ocamt/bin/pip install --no-cache-dir -e git+https://github.com/OCA/maintainer-tools@568cacd1d6eef453063a524a5ce63dcd49c7259b#egg=oca-maintainers-tools \
   && ln -s /ocamt/bin/oca-gen-addons-table /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-readme /usr/local/bin/ \
-  && ln -s /ocamt/bin/oca-towncrier /usr/local/bin/
-RUN set -x \
-  && /ocamt/bin/pip install --no-cache-dir 'setuptools-odoo>=3.0.3' \
+  && ln -s /ocamt/bin/oca-gen-metapackage /usr/local/bin/ \
+  && ln -s /ocamt/bin/oca-towncrier /usr/local/bin/ \
   && ln -s /ocamt/bin/setuptools-odoo-make-default /usr/local/bin/
 
 # isolate from system python libraries

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
         "lxml",
         # for setuptools-odoo-make-default
         "setuptools-odoo",
+        # for whool-init
+        "whool",
         # packaging
         "packaging>=22",
     ],

--- a/src/oca_github_bot/config.py
+++ b/src/oca_github_bot/config.py
@@ -59,7 +59,7 @@ DRY_RUN = os.environ.get("DRY_RUN", "").lower() in ("1", "true", "yes")
 # Available tasks:
 #  delete_branch,tag_approved,tag_ready_to_merge,gen_addons_table,
 #  gen_addons_readme,gen_addons_icon,setuptools_odoo,merge_bot,tag_needs_review,
-#  migration_issue_bot
+#  migration_issue_bot,whool_init,gen_metapackage
 BOT_TASKS = os.environ.get("BOT_TASKS", "all").split(",")
 
 BOT_TASKS_DISABLED = os.environ.get("BOT_TASKS_DISABLED", "").split(",")
@@ -143,4 +143,10 @@ WHEEL_BUILD_TOOLS = os.environ.get(
     "build,pip,setuptools<58,wheel,setuptools-odoo,whool",
 ).split(",")
 
+# minimum Odoo series supported by the bot
 MAIN_BRANCH_BOT_MIN_VERSION = os.environ.get("MAIN_BRANCH_BOT_MIN_VERSION", "8.0")
+
+# First Odoo Series for which the whool_init and gen_metapackage tasks are run on main
+# branches. For previous versions, the setuptools_odoo task is run and generates
+# setup.py instead of pyproject.toml.
+GEN_PYPROJECT_MIN_VERSION = os.environ.get("GEN_PYPROJECT_MIN_VERSION", "17.0")

--- a/src/oca_github_bot/github.py
+++ b/src/oca_github_bot/github.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 
 import appdirs
 import github3
@@ -159,3 +160,13 @@ def git_get_head_sha(cwd):
 
 def git_get_current_branch(cwd):
     return check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd).strip()
+
+
+def git_commit_if_needed(glob_pattern, msg, cwd):
+    files = [p.absolute() for p in Path(cwd).glob(glob_pattern)]
+    if not files:
+        return  # no match nothing to commit
+    check_call(["git", "add", *files], cwd=cwd)
+    if call(["git", "diff", "--cached", "--quiet", "--exit-code"], cwd=cwd) == 0:
+        return  # nothing added
+    return check_call(["git", "commit", "-m", msg], cwd=cwd)

--- a/src/oca_github_bot/version_branch.py
+++ b/src/oca_github_bot/version_branch.py
@@ -17,11 +17,18 @@ MERGE_BOT_BRANCH_RE = re.compile(
 )
 
 
-def is_main_branch_bot_branch(branch_name):
+def is_supported_main_branch(branch_name, min_version=None):
     if not ODOO_VERSION_RE.match(branch_name):
         return False
-    return version.parse(branch_name) >= version.parse(
-        config.MAIN_BRANCH_BOT_MIN_VERSION
+    branch_version = version.parse(branch_name)
+    if min_version and branch_version < version.parse(min_version):
+        return False
+    return True
+
+
+def is_main_branch_bot_branch(branch_name):
+    return is_supported_main_branch(
+        branch_name, min_version=config.MAIN_BRANCH_BOT_MIN_VERSION
     )
 
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,8 +3,13 @@
 
 import re
 import subprocess
+from pathlib import Path
 
-from oca_github_bot.github import git_get_current_branch, git_get_head_sha
+from oca_github_bot.github import (
+    git_commit_if_needed,
+    git_get_current_branch,
+    git_get_head_sha,
+)
 
 
 def test_git_get_head_sha(git_clone):
@@ -16,3 +21,36 @@ def test_git_get_current_branch(git_clone):
     assert git_get_current_branch(git_clone) == "master"
     subprocess.check_call(["git", "checkout", "-b", "abranch"], cwd=git_clone)
     assert git_get_current_branch(git_clone) == "abranch"
+
+
+def test_git_commit_if_needed_no_change(tmp_path: Path) -> None:
+    subprocess.check_call(["git", "init"], cwd=tmp_path)
+    subprocess.check_call(
+        ["git", "config", "user.email", "test@example.com"], cwd=tmp_path
+    )
+    subprocess.check_call(["git", "config", "user.name", "test"], cwd=tmp_path)
+    toto = tmp_path / "toto"
+    toto.touch()
+    git_commit_if_needed("toto", "initial commit", cwd=tmp_path)
+    head_sha = git_get_head_sha(tmp_path)
+    # no change
+    git_commit_if_needed("toto", "no commit", cwd=tmp_path)
+    assert git_get_head_sha(tmp_path) == head_sha
+    # change in existing file
+    toto.write_text("toto")
+    git_commit_if_needed("toto", "toto changed", cwd=tmp_path)
+    head_sha2 = git_get_head_sha(tmp_path)
+    assert head_sha2 != head_sha
+    # add subdirectory
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    titi = subdir / "titi"
+    titi.touch()
+    git_commit_if_needed("subdir", "titi added", cwd=tmp_path)
+    head_sha3 = git_get_head_sha(tmp_path)
+    assert head_sha3 != head_sha2
+    # add glob
+    subdir.joinpath("pyproject.toml").touch()
+    git_commit_if_needed("*/pyproject.toml", "pyproject.toml added", cwd=tmp_path)
+    head_sha4 = git_get_head_sha(tmp_path)
+    assert head_sha4 != head_sha3

--- a/tests/test_version_branch.py
+++ b/tests/test_version_branch.py
@@ -1,10 +1,13 @@
 # Copyright (c) ACSONE SA/NV 2018
 # Distributed under the MIT License (http://opensource.org/licenses/MIT).
 
+import pytest
+
 from oca_github_bot.version_branch import (
     is_main_branch_bot_branch,
     is_merge_bot_branch,
     is_protected_branch,
+    is_supported_main_branch,
     make_merge_bot_branch,
     parse_merge_bot_branch,
     search_merge_bot_branch,
@@ -72,3 +75,15 @@ def test_search_merge_bot_branch():
     assert search_merge_bot_branch(text) == "12.0-ocabot-merge-pr-100-by-toto-bump-no"
     text = "blah blah more stuff"
     assert search_merge_bot_branch(text) is None
+
+
+@pytest.mark.parametrize(
+    ("branch_name", "min_version", "expected"),
+    [
+        ("8.0", None, True),
+        ("8.0", "8.0", True),
+        ("8.0", "9.0", False),
+    ],
+)
+def test_is_supported_branch(branch_name, min_version, expected):
+    assert is_supported_main_branch(branch_name, min_version) is expected


### PR DESCRIPTION
By default, this is done for branches 17.0+.

The minimum version to generate pyproject.toml instead of setup.py is configurable with `GEN_PYPROJECT_MIN_VERSION` and there are two new switchable tasks: `whool_init` and `gen_metapackage`.