### PR TITLE
Don't prepend current directory when building

### DIFF
--- a/src/oca_github_bot/build_wheels.py
+++ b/src/oca_github_bot/build_wheels.py
@@ -51,6 +51,7 @@ class Builder:
             check_call(
                 [
                     self.env_python,
+                    "-P",
                     "-m",
                     "build",
                     "--wheel",


### PR DESCRIPTION
This should fix https://github.com/OCA/rest-framework/pull/397#issuecomment-2301739586