### PR TITLE
Simplify installation of oca-gen-addon-icon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,6 @@ RUN set -x \
 # The main branch bot needs several other command line tools from in OCA/maintainer-tools
 # we install them in a separate virtualenv to avoid polluting our main environment.
 
-# Install a specific version of icon generator, to ensure stability as any tiny change
-# in generated output may create many commits on all addons.
-RUN set -x \
-  && python${PY} -m venv /ocamt-pinned \
-  && /ocamt-pinned/bin/pip install --no-cache-dir -U pip wheel
-RUN set -x \
-  && /ocamt-pinned/bin/pip install --no-cache-dir -e git+https://github.com/OCA/maintainer-tools@969238e47c07d0c40573acff81d170f63245d738#egg=oca-maintainers-tools \
-  && ln -s /ocamt-pinned/bin/oca-gen-addon-icon /usr/local/bin/
-
 # Other oca maintainer tools that are less sensitive to changes. The README generator is
 # not as sensitive as before because it now stores a hash of the fragments in the
 # generated README.rst, so it will only regenerate if the fragments have changed.
@@ -42,6 +33,7 @@ RUN set -x \
   && /ocamt/bin/pip install --no-cache-dir -e git+https://github.com/OCA/maintainer-tools@fbdc8945feabe1f6f3091c1b2d517b6c4160bc2b#egg=oca-maintainers-tools \
   && ln -s /ocamt/bin/oca-gen-addons-table /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-addon-readme /usr/local/bin/ \
+  && ln -s /ocamt/bin/oca-gen-addon-icon /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-gen-metapackage /usr/local/bin/ \
   && ln -s /ocamt/bin/oca-towncrier /usr/local/bin/ \
   && ln -s /ocamt/bin/setuptools-odoo-make-default /usr/local/bin/ \


### PR DESCRIPTION
The icon generator will not overwrite existing icons, so there is no need to pin it.

The pinning was initially done out of fear an icon generator update would overwrite all icons at once.