### PR TITLE
use git+ssh for use with private repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /tmp/
 /environment*
 /.vscode
+/ssh
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ENV LANG=C.UTF-8 \
     DEBIAN_FRONTEND=noninteractive
 
 ARG PY=3.12
+# UID / GID needed for git by ssh
+ARG UID
+ARG GID
 
 # binutils is needed for the ar command, used by pypandoc.ensure_pandoc_installed()
 RUN set -x \
@@ -55,5 +58,17 @@ RUN pip install --no-cache-dir -e /app/src/oca-github-bot
 
 # make work and home directory
 RUN mkdir /app/run && chmod ogu+rwx /app/run
+RUN groupadd -g $GID -o app
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash app
+
 ENV HOME=/app/run
 WORKDIR /app/run
+
+# git: change all url to ssh instead of HTTP
+# in order to avoid GITHUB_TOKEN leaks in error messages
+RUN git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+COPY ./ssh /home/app/.ssh/
+RUN chown app /home/app/.ssh
+RUN chown app /home/app/.ssh/*
+
+USER app

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,14 @@ The bot URL must be exposed on the internet through a reverse
 proxy and configured as a GitHub webhook, using the secret configured
 in ``GITHUB_SECRET``.
 
+Private repo support
+===========
+
+If the bot needs to access private github repository, you should generate
+a new key, and give access to this key on github.
+If running from docker, it should be placed on a `ssh` directory on the root of this
+repo.
+
 Development
 ===========
 
@@ -233,6 +241,7 @@ Contributors
 * Sylvain Le Gal (https://twitter.com/legalsylvain)
 * Tecnativa - Pedro M. Baeza
 * Tecnativa - Víctor Martínez
+* Raphaël Reverdy <raphael.reverdy@akretion.com>
 
 Maintainers
 ===========


### PR DESCRIPTION
Still experimental

I need to access private github repo.

In https://github.com/OCA/oca-github-bot/blob/master/src/oca_github_bot/github.py
```py
    repo_url = f"https://github.com/{org}/{repo}"
    repo_url_with_token = f"https://{config.GITHUB_TOKEN}@github.com/{org}/{repo}"
    # fetch all branches into cache
    fetch_cmd = [
        "git",
        "fetch",
        "--quiet",
        "--force",
        "--prune",
        repo_url,
        "refs/heads/*:refs/heads/*",
    ]
```
for `git fetch`  repo_url is used instead of repo_url_with_token; I'm not sure if the repo_url is displayed in case of error messages.

Using ssh protocol instead of http is easier to use in my case.

It's working but at the moment half finished.