### PR TITLE
[IMP] /ocabot merge: ignore skipped check suites

### DIFF
--- a/src/oca_github_bot/tasks/merge_bot.py
+++ b/src/oca_github_bot/tasks/merge_bot.py
@@ -371,6 +371,13 @@ def _get_commit_success(org, repo, pr, gh_commit):
                 f"PR #{pr} of {org}/{repo}"
             )
             success = True
+        elif check_suite.conclusion == "skipped":
+            # skipped
+            _logger.info(
+                f"Ignoring skipped check suite {check_suite.app.name} for "
+                f"PR #{pr} of {org}/{repo}"
+            )
+            continue
         elif not check_suite.conclusion:
             # not complete
             check_runs = list(github.gh_call(check_suite.check_runs))


### PR DESCRIPTION
In OpenUpgrade, we have a workflow that is [skipped](https://github.com/OCA/OpenUpgrade/blob/18.0/.github/workflows/generate-analysis-cron.yml#L14) most of the time because it's super resource consuming and only makes sense to be run after merge on the main branch anyways.

Without this, ocabot treats commits with skipped workflows as [failed](https://github.com/OCA/OpenUpgrade/pull/5443#issuecomment-3733034406), which it shouldn't.

fixes #326