### PR TITLE
Pin setuptools-odoo>=3.3.2 to include fix for the removal of 'pkg_res…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,8 @@ rfc3986==2.0.0
 rich==14.2.0
 secretstorage==3.4.0
 sentry-sdk==1.45.1
-setuptools==80.9.0
-setuptools-odoo==3.3.1
+setuptools==81.0.0
+setuptools-odoo==3.3.2
 setuptools-scm==9.2.2
 six==1.17.0
 tornado==6.5.2

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         # lxml for parsing PyPI index pages
         "lxml",
         # for setuptools-odoo-make-default
-        "setuptools-odoo",
+        "setuptools-odoo>=3.3.2",
         "setuptools",
         # for whool-init
         "whool",


### PR DESCRIPTION
…ources' from setuptools==82